### PR TITLE
fix formatted dongle id

### DIFF
--- a/custom_components/monitormysolar/sensor.py
+++ b/custom_components/monitormysolar/sensor.py
@@ -707,7 +707,7 @@ class CalculatedSensor(MonitorMySolarEntity, SensorEntity):
 
         # Store the formatted IDs
         self._dongle_id = dongle_id  # For device_info
-        self._formatted_id = dongle_id.replace(":", "_")   # For sensor entity matching
+        self._formatted_id = self.coordinator.get_formatted_dongle_id(dongle_id)   # For sensor entity matching
 
         self._sensor_type = sensor_info["unique_id"]
         self.entity_id = f"sensor.{self._formatted_id}_{self._sensor_type.lower()}"


### PR DESCRIPTION
The dongle ID was not matching the correct format needed to match the coordinator entities. The `dongle-` needed to be `dongle_`. Used the new function from the coordinator to get the correct ID.