### PR TITLE
Monitor my solar staging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 custom_components/monitormysolar/__pycache__
 custom_components/monitormysolar/.claude
 custom_components/monitormysolar/docs/
+custom_components/monitormysolar/registers
 ./claude
 *.claude
 claude.md

--- a/custom_components/monitormysolar/CHANGELOG.md
+++ b/custom_components/monitormysolar/CHANGELOG.md
@@ -1,5 +1,88 @@
 # Changelog
 
+## Version 3.1.0 - GridBoss Enhancements & Performance Improvements
+
+### 🔄 **Important: GridBoss Upgrade Instructions**
+If you are using GridBoss functionality, please follow these steps to upgrade:
+1. **Delete the integration** from Home Assistant
+2. **Reboot** Home Assistant
+3. **Update through HACS** to get the latest version
+4. **Re-setup** the integration with your GridBoss configuration
+
+This ensures a clean upgrade and prevents any configuration conflicts with the new GridBoss features.
+- **Multi-Inverter**: Enhanced support for parallel inverter configurations with GridBoss
+
+### 🚀 Major Performance Improvements
+- **Fixed Home Assistant Slow Startup**: Implemented startup delay to prevent MQTT message processing during HA initialization
+- **Eliminated Excessive Coordinator Updates**: Reduced coordinator update frequency from every 1.5 seconds to only when needed
+- **Optimized MQTT Processing**: Deferred non-critical MQTT message processing until after HA startup completion
+- **Improved Main Thread Performance**: Prevented blocking operations during Home Assistant startup
+- **Resolved Bootstrap Timeout**: Fixed blocking `while True:` loop in SyncStatusSensor that was causing 5+ minute startup times
+- **Non-Blocking Async Scheduling**: Replaced blocking loops with proper async scheduling using `async_call_later()`
+
+### 🔧 GridBoss Configuration & Setup Fixes
+- **Enhanced Config Flow**: Added dedicated GridBoss configuration step with proper dongle selection
+- **Improved Error Handling**: Added comprehensive error handling for dongle connectivity and firmware code reception
+- **Fixed Entity Creation Logic**: Implemented strict GridBoss entity filtering to prevent creation of unnecessary standard entities
+- **Corrected Device Naming**: Fixed GridBoss device naming to display "GridBoss" instead of generic names
+
+### 📡 GridBoss MQTT & Payload Processing
+- **Fixed Nested Payload Parsing**: Implemented proper handling of GridBoss nested JSON payload structure
+- **Corrected Entity Name Mapping**: Fixed mapping between payload keys and entity unique_ids
+- **Enhanced Topic Routing**: Improved MQTT topic routing for GridBoss-specific settings
+- **Simplified Payload Processing**: Streamlined nested data processing with recursive flattening
+
+### 🛠️ Technical Improvements
+- **Removed Complex Throttling**: Simplified coordinator update mechanism for better performance
+- **Enhanced Fault/Warning Deduplication**: Prevented duplicate processing of identical fault/warning data
+- **Improved Entity Type Determination**: Optimized entity type detection for better performance
+- **Better Error Recovery**: Enhanced error handling and recovery mechanisms
+
+### 🎯 User Experience Enhancements
+- **Faster Home Assistant Startup**: Reduced startup time by deferring MQTT processing
+- **Cleaner Debug Logs**: Eliminated excessive "Manually updated MonitorySolar Coordinator data" messages
+- **More Responsive Interface**: Home Assistant becomes responsive much faster after restart
+- **Better Configuration Flow**: Improved GridBoss setup process with clear error messages
+
+### 🔄 Backward Compatibility
+- **Maintained All Existing Features**: All previous functionality preserved
+- **No Breaking Changes**: Existing configurations continue to work without modification
+- **Preserved Entity History**: All entity data and settings remain intact
+- **Seamless Upgrade Path**: No manual intervention required for existing users
+
+### 📋 Technical Details
+- **Startup Delay**: 30-second delay before MQTT message processing begins
+- **Firmware Code Processing**: Still processed immediately for proper entity creation
+- **GridBoss Entity Filtering**: Only creates entities explicitly allowed for "IAAB" firmware
+- **Payload Structure**: Supports both old and new nested payload formats
+
+### 🐛 Bug Fixes
+- Fixed `IndentationError` in sensor.py that prevented integration loading
+- Resolved `NameError: name 'data_to_process' is not defined` in coordinator
+- Fixed GridBoss entity count issues (was creating ~400 entities, now creates only relevant ones)
+- Corrected GridBoss device naming in Home Assistant interface
+- Fixed nested payload parsing for GridBoss settings updates
+- **Fixed Home Assistant startup timeout**: Replaced blocking `while True:` loop in SyncStatusSensor with non-blocking async scheduling
+- **Resolved 5+ minute startup times**: Prevented bootstrap timeout warnings and excessive coordinator updates during startup
+- **Fixed GridBoss MQTT routing issue**: GridBoss settings were incorrectly being sent to bank-specific topics instead of the standard `/update` topic, causing settings to be rejected
+- **Enhanced GridBoss conditional entity system**: Implemented hierarchical availability logic based on Port Mode → SOC/Volt mode → Enable state
+- **Added Port Mode selects**: New SmartLoad1-4 Port Mode selects with proper numeric value mapping (0=Does Not Operate, 1=Smart Load, 2=AC Coupled)
+- **Fixed switch availability logic**: Added proper availability checking to switch entities based on Port Mode, SOC/Volt mode, and SmartLoad enable state
+- **Firmware code persistence**: Firmware codes are now saved to config entry data and only requested when not already available, improving startup performance
+- **Fixed availability timing issue**: Added 0.5s delay to availability updates to prevent blocking legitimate user actions when Port Mode changes
+- **Removed availability blocking from user actions**: Availability logic now only affects UI display (grayed out entities) but no longer blocks user actions, preventing the "revert" issue
+- **Fixed select entity revert issue**: Select entities now properly store previous state before changing and revert correctly on MQTT failure, preventing the auto-revert issue with Port Mode selects
+- **Fixed coordinator override issue**: Added user-initiated change flag to prevent coordinator from overriding user selections during MQTT processing, solving the select revert problem
+- **Fixed availability delay issue**: Port Mode changes now trigger immediate availability updates, and enable switches are always available when Port Mode is set to "Smart Load" or "AC Coupled" (both SmartLoad and AC Coupled enable switches)
+- **Added SOC/Volt mode select entities**: New SmartLoad1-4 Mode selects with "Time" and "SOC/Volt" options, available when Port Mode is set to "Smart Load" or "AC Coupled"
+
+### 📝 Notes
+- **Dongle Firmware**: Requires dongle firmware 3.1.0+ for optimal GridBoss functionality
+- **Performance**: Significant improvement in Home Assistant startup time
+- **GridBoss**: Full support for GridBoss units with firmware code "IAAB"
+
+---
+
 ## Version 3.0.1 - GridBoss Support & Enhanced Multi-Inverter Features
 
 ### Minimum Requirements include the dongle Firmware 3.0.0> if your dongle is below this then a OTA update will be required. 

--- a/custom_components/monitormysolar/CONDITIONAL_ENTITIES.md
+++ b/custom_components/monitormysolar/CONDITIONAL_ENTITIES.md
@@ -1,0 +1,174 @@
+# Conditional Entity System for GridBoss SmartLoad Settings
+
+## Overview
+
+This document describes the implementation of a conditional entity system that dynamically enables/disables GridBoss SmartLoad settings based on two key configurations:
+1. **SmartSOCVoltBits**: Controls SOC/Volt vs Time mode
+2. **SmartLoad Bits**: Controls which SmartLoads are enabled
+
+This solves the challenge of having dependent settings where some values can only be set when other settings have specific values.
+
+## Problem Statement
+
+In GridBoss systems, certain settings have dependencies:
+
+### SmartLoad Enable/Disable
+- **Disabled SmartLoads**: When `SmartLoadX_Enable` is `false`, all related settings should be unavailable
+- **Enabled SmartLoads**: When `SmartLoadX_Enable` is `true`, related settings become available
+
+### SOC/Volt vs Time Mode
+- **SOC/Volt Mode**: When `SmartLoadX_SOC_Volt` is `true`, only SOC and voltage-based settings are available
+- **Time Mode**: When `SmartLoadX_SOC_Volt` is `false`, only time-based settings are available
+
+### Always Available Settings
+- **Enable/Disable Switches**: Always available regardless of other settings
+
+Home Assistant doesn't provide built-in popup alerts or dynamic entity enabling/disabling, so we needed a creative solution.
+
+## Solution Architecture
+
+### 1. SmartSOCVoltBits and SmartLoad Bits Tracking
+
+The coordinator now tracks both configuration types for each dongle:
+
+```python
+self._smart_soc_volt_bits = {}  # Track SmartSOCVoltBits for each dongle
+self._smartload_bits = {}  # Track SmartLoad Bits for each dongle
+```
+
+### 2. Entity Availability System
+
+Entities use the `available` property to dynamically show/hide based on dependency settings:
+
+```python
+@property
+def available(self) -> bool:
+    """Return if entity is available."""
+    if not self.coordinator.last_update_success:
+        return False
+    
+    # Check if entity should be available based on SmartLoad SOC/Volt settings
+    return self.coordinator.is_entity_available_for_smartload(self._dongle_id, self._entity_type)
+```
+
+### 3. Validation and User Feedback
+
+When users try to set invalid values, the system:
+1. Prevents the setting from being applied
+2. Shows a persistent notification explaining why the setting is unavailable
+3. Logs a warning message
+
+## Implementation Details
+
+### Coordinator Methods
+
+#### `update_smart_soc_volt_bits(dongle_id, smart_soc_volt_bits)`
+Updates the SmartSOCVoltBits settings and triggers entity availability updates.
+
+#### `update_smartload_bits(dongle_id, smartload_bits)`
+Updates the SmartLoad Bits settings and triggers entity availability updates.
+
+#### `is_entity_available_for_smartload(dongle_id, entity_unique_id)`
+Determines if an entity should be available based on:
+- Whether it's a GridBoss dongle
+- The SmartLoad number (1-4)
+- Whether the SmartLoad is enabled
+- Whether it's a SOC/Volt or Time entity
+- The current SmartSOCVoltBits setting
+
+#### `is_smartload_enabled(dongle_id, smartload_number)`
+Checks if a specific SmartLoad is enabled.
+
+#### `is_entity_available_for_smartload_enable(dongle_id, entity_unique_id)`
+Checks availability based only on SmartLoad enable state (used for Enable/Disable switches).
+
+#### `_trigger_entity_availability_update(dongle_id)`
+Triggers async updates to entity availability when SmartSOCVoltBits change.
+
+### Entity Classification
+
+The system classifies entities into categories:
+
+**SOC/Volt Entities** (available when `SmartLoadX_SOC_Volt` is `true`):
+- `StartSOC`, `EndSOC`
+- `StartVolt`, `EndVolt`
+- `SheddingStartSOC`, `SheddingEndSOC`
+- `SheddingStartVolt`, `SheddingEndVolt`
+
+**Time Entities** (available when `SmartLoadX_SOC_Volt` is `false`):
+- `Start0`, `End0`
+- `Start1`, `End1`
+- `Start2`, `End2`
+
+### User Experience
+
+1. **Visual Feedback**: Unavailable entities appear grayed out in Home Assistant
+2. **Prevention**: Users cannot set values on unavailable entities
+3. **Notifications**: Clear explanations when users try to access unavailable settings
+4. **Dynamic Updates**: Entities become available/unavailable automatically when SmartSOCVoltBits change
+
+## Example Usage
+
+### Complete SmartLoad Configuration
+
+```json
+"SmartLoad": {
+  "Bits": {
+    "SmartLoad1_Enable": true,
+    "SmartLoad2_Enable": true,
+    "SmartLoad3_Enable": false,
+    "SmartLoad4_Enable": false
+  }
+},
+"SmartSOCVoltBits": {
+  "SmartLoad1_SOC_Volt": true,
+  "SmartLoad2_SOC_Volt": false,
+  "SmartLoad3_SOC_Volt": true,
+  "SmartLoad4_SOC_Volt": false
+}
+```
+
+**Result**:
+- **SmartLoad1**: ✅ Enabled + SOC/Volt mode → SOC/Volt entities available, Time entities unavailable
+- **SmartLoad2**: ✅ Enabled + Time mode → Time entities available, SOC/Volt entities unavailable  
+- **SmartLoad3**: ❌ Disabled → All entities unavailable (except Enable switch)
+- **SmartLoad4**: ❌ Disabled → All entities unavailable (except Enable switch)
+
+### User Interaction Examples
+
+#### Example 1: Disabled SmartLoad
+1. User tries to set `SmartLoad3StartSOC` when `SmartLoad3_Enable` is `false`
+2. System shows notification: "The setting 'SmartLoad3 Start SOC' is not available because SmartLoad3 is disabled. Please enable SmartLoad3 first."
+3. Entity remains grayed out until SmartLoad3 is enabled
+
+#### Example 2: Wrong Mode
+1. User tries to set `SmartLoad1Start0` (time entity) when `SmartLoad1_SOC_Volt` is `true`
+2. System shows notification: "The setting 'SmartLoad1 Start0' is not available because SmartLoad1 is configured for Time mode. Please change to SOC/Volt mode first."
+3. Entity remains grayed out until SmartLoad mode changes
+
+#### Example 3: Always Available
+1. User can always access `SmartLoad1_Enable` switch regardless of other settings
+2. This allows users to enable/disable SmartLoads as needed
+
+## Benefits
+
+1. **Prevents Invalid Configurations**: Users cannot set conflicting settings
+2. **Clear User Feedback**: Persistent notifications explain why settings are unavailable
+3. **Dynamic Behavior**: Entities automatically update when dependencies change
+4. **No Breaking Changes**: Existing functionality remains intact
+5. **Extensible**: System can be extended for other conditional settings
+
+## Technical Notes
+
+- The system uses Home Assistant's built-in `available` property
+- Persistent notifications provide user feedback without popups
+- Entity availability updates are triggered asynchronously
+- The system gracefully handles missing or incomplete SmartSOCVoltBits data
+- All changes are backward compatible
+
+## Future Enhancements
+
+1. **Additional Dependencies**: Extend to other conditional settings
+2. **Bulk Operations**: Handle multiple entity updates more efficiently
+3. **Configuration UI**: Add visual indicators in the configuration flow
+4. **Automation Support**: Allow automations to be aware of entity availability

--- a/custom_components/monitormysolar/binary_sensor.py
+++ b/custom_components/monitormysolar/binary_sensor.py
@@ -32,9 +32,26 @@ async def async_setup_entry(
     for dongle_id in dongle_ids:
         firmware_code = coordinator.get_firmware_code(dongle_id)
         
+        # Only create entities if we have a firmware code
+        if not firmware_code:
+            LOGGER.debug(f"Skipping entity creation for {dongle_id} - no firmware code available yet")
+            continue
+        
         # Loop through the sensors in the configuration for this dongle
         for bank_name, sensors in sensors_config.items():
             for sensor in sensors:
+                allowed_firmware_codes = sensor.get("allowed_firmware_codes", [])
+                # For GridBoss dongles (IAAB), only create entities that explicitly allow this firmware code
+                if coordinator.is_gridboss_dongle(dongle_id):
+                    if not allowed_firmware_codes or firmware_code not in allowed_firmware_codes:
+                        continue
+                else:
+                    # For regular dongles, use the original logic
+                    if not allowed_firmware_codes or firmware_code in allowed_firmware_codes:
+                        pass  # Continue to entity creation
+                    else:
+                        continue  # Skip this entity
+                
                 if bank_name == "battery":
                     entities.append(
                         BatteryStatusBinarySensor(sensor, hass, entry, dongle_id)

--- a/custom_components/monitormysolar/button.py
+++ b/custom_components/monitormysolar/button.py
@@ -24,9 +24,26 @@ async def async_setup_entry(hass, entry: MonitorMySolarEntry, async_add_entities
         firmware_code = coordinator.get_firmware_code(dongle_id)
         device_type = FIRMWARE_CODES.get(firmware_code, {}).get("Device_Type", "")
         
+        # Only create entities if we have a firmware code
+        if not firmware_code:
+            LOGGER.debug(f"Skipping entity creation for {dongle_id} - no firmware code available yet")
+            continue
+        
         # Process buttons for this dongle
         for bank_name, buttons in buttons_config.items():
             for button in buttons:
+                allowed_firmware_codes = button.get("allowed_firmware_codes", [])
+                # For GridBoss dongles (IAAB), only create entities that explicitly allow this firmware code
+                if coordinator.is_gridboss_dongle(dongle_id):
+                    if not allowed_firmware_codes or firmware_code not in allowed_firmware_codes:
+                        continue
+                else:
+                    # For regular dongles, use the original logic
+                    if not allowed_firmware_codes or firmware_code in allowed_firmware_codes:
+                        pass  # Continue to entity creation
+                    else:
+                        continue  # Skip this entity
+                
                 try:
                     if bank_name == "inputbank1": 
                         entities.append(

--- a/custom_components/monitormysolar/config_flow.py
+++ b/custom_components/monitormysolar/config_flow.py
@@ -67,20 +67,28 @@ class InverterMQTTFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             # Normalize the dongle ID
             user_input["dongle_id"] = self._normalize_dongle_id(user_input["dongle_id"])
             
-            # If parallel inverters is selected, store the data and move to the parallel step
-            if user_input.get("parallel_inverters", False):
-                self.initial_data = user_input
+            # Store initial data
+            self.initial_data = user_input
+            
+            # Determine next step based on selections
+            if user_input.get("parallel_inverters", False) and user_input.get("has_gridboss", False):
+                # Both parallel and GridBoss selected - go to parallel first, then GridBoss
                 return await self.async_step_parallel()
-            
-            # If no parallel inverters, create a single dongle entry
-            user_input["dongle_ids"] = [user_input["dongle_id"]]
-            user_input["dongle_ips"] = [user_input.get("dongle_ip", "")]
-            
-            # Once the user submits the form, create the entry
-            return self.async_create_entry(
-                title=f"{user_input['inverter_brand']} - {user_input['dongle_id']}",
-                data=user_input,
-            )
+            elif user_input.get("parallel_inverters", False):
+                # Only parallel selected
+                return await self.async_step_parallel()
+            elif user_input.get("has_gridboss", False):
+                # Only GridBoss selected
+                return await self.async_step_gridboss()
+            else:
+                # Neither selected - create single dongle entry
+                user_input["dongle_ids"] = [user_input["dongle_id"]]
+                user_input["dongle_ips"] = [user_input.get("dongle_ip", "")]
+                
+                return self.async_create_entry(
+                    title=f"{user_input['inverter_brand']} - {user_input['dongle_id']}",
+                    data=user_input,
+                )
 
         _LOGGER.debug("Displaying the form with translations")
 
@@ -124,14 +132,21 @@ class InverterMQTTFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     additional_ip = user_input.get(f"dongle_ip_{i+1}", "")
                     dongle_ips.append(additional_ip)
             
-            # Combine all data
-            combined_data = {**self.initial_data, **user_input, "dongle_ids": dongle_ids, "dongle_ips": dongle_ips}
+            # Update initial data with parallel dongle info
+            self.initial_data.update({
+                "dongle_ids": dongle_ids,
+                "dongle_ips": dongle_ips
+            })
             
-            # Create the entry with all the data
-            return self.async_create_entry(
-                title=f"{self.initial_data['inverter_brand']} - Multiple Dongles",
-                data=combined_data,
-            )
+            # Check if we need to go to GridBoss step
+            if self.initial_data.get("has_gridboss", False):
+                return await self.async_step_gridboss()
+            else:
+                # Create the entry with all the data
+                return self.async_create_entry(
+                    title=f"{self.initial_data['inverter_brand']} - Multiple Dongles",
+                    data=self.initial_data,
+                )
 
         # Create schema for additional dongles
         schema = vol.Schema(
@@ -146,6 +161,43 @@ class InverterMQTTFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
         return self.async_show_form(step_id="parallel", data_schema=schema, errors=errors)
+
+    async def async_step_gridboss(self, user_input=None):
+        """Handle the GridBoss configuration step."""
+        errors = {}
+
+        if user_input is not None:
+            # Get the GridBoss dongle selection
+            gridboss_dongle = user_input.get("gridboss_dongle", "")
+            
+            # Update initial data with GridBoss info
+            self.initial_data["gridboss_dongle"] = gridboss_dongle
+            
+            # Create the entry with all the data
+            return self.async_create_entry(
+                title=f"{self.initial_data['inverter_brand']} - GridBoss Configuration",
+                data=self.initial_data,
+            )
+
+        # Create schema for GridBoss dongle selection
+        # Build the options based on available dongles
+        dongle_options = {"": "None"}
+        
+        # Add first dongle
+        dongle_options["dongle_id"] = f"First Dongle ({self.initial_data['dongle_id']})"
+        
+        # Add additional dongles if they exist
+        dongle_ids = self.initial_data.get("dongle_ids", [])
+        for i in range(1, len(dongle_ids)):
+            dongle_options[f"dongle_id_{i+1}"] = f"Dongle {i+1} ({dongle_ids[i]})"
+
+        schema = vol.Schema(
+            {
+                vol.Required("gridboss_dongle"): vol.In(dongle_options),
+            }
+        )
+
+        return self.async_show_form(step_id="gridboss", data_schema=schema, errors=errors)
 
     async def async_setup_entry(self, hass, entry):
         _LOGGER.info("Monitor My Solar Being Setup")

--- a/custom_components/monitormysolar/const.py
+++ b/custom_components/monitormysolar/const.py
@@ -166,6 +166,24 @@ FIRMWARE_CODES = {
             "B": "Parallel Model",
             "C": "Others"
         }
+    },
+    "I_GridBoss": {
+        "Device_Type": "I GridBoss Model",
+        "Derived_Device_Type": {
+            "A": "Standard Model",
+            "B": "Others",
+            "C": "Others"
+        },
+        "ODM_Code": {
+            "A": "Luxpower",
+            "B": "Others",
+            "C": "Others"
+        },
+        "Feature_Code": {
+            "A": "Standard Model",
+            "B": "Parallel Model",
+            "C": "Others"
+        }
     }
 }
 
@@ -715,6 +733,16 @@ ENTITIES = {
                 "holdbank6": [
                     {"name": "Quick Charge Duration", "type": "select", "unique_id": "quickchgtime", "options": ["0", "15", "30", "45", "60", "90", "120"], "additional_payload": {"key": "ubquickchgstarten","value_map": {"0": "0","default": "1"}}},
 
+                ],
+                "gridboss_holdbank1": [
+                    {"name": "Smart Port 1", "type": "select", "unique_id": "SmartLoad1_PortMode", "options": ["Does Not Operate", "Smart Load", "Ac Coupled"], "allowed_firmware_codes": ["IAAB"]},
+                    {"name": "Smart Port 2", "type": "select", "unique_id": "SmartLoad2_PortMode", "options": ["Does Not Operate", "Smart Load", "Ac Coupled"], "allowed_firmware_codes": ["IAAB"]},
+                    {"name": "Smart Port 3", "type": "select", "unique_id": "SmartLoad3_PortMode", "options": ["Does Not Operate", "Smart Load", "Ac Coupled"], "allowed_firmware_codes": ["IAAB"]},
+                    {"name": "Smart Port 4", "type": "select", "unique_id": "SmartLoad4_PortMode", "options": ["Does Not Operate", "Smart Load", "Ac Coupled"], "allowed_firmware_codes": ["IAAB"]},
+                    {"name": "Smart Load 1 Mode", "type": "select", "unique_id": "SmartLoad1_SOC_Volt", "options": ["Time", "SOC/Volt"], "allowed_firmware_codes": ["IAAB"]},
+                    {"name": "Smart Load 2 Mode", "type": "select", "unique_id": "SmartLoad2_SOC_Volt", "options": ["Time", "SOC/Volt"], "allowed_firmware_codes": ["IAAB"]},
+                    {"name": "Smart Load 3 Mode", "type": "select", "unique_id": "SmartLoad3_SOC_Volt", "options": ["Time", "SOC/Volt"], "allowed_firmware_codes": ["IAAB"]},
+                    {"name": "Smart Load 4 Mode", "type": "select", "unique_id": "SmartLoad4_SOC_Volt", "options": ["Time", "SOC/Volt"], "allowed_firmware_codes": ["IAAB"]},
                 ]
             },
             "button": {
@@ -807,7 +835,8 @@ ENTITIES = {
                          "type": "update", 
                          "unique_id": "firmware_update",
                          "version_key": "SW_VERSION",
-                         "update_command": "updatedongle"
+                         "update_command": "updatedongle",
+                         "allowed_firmware_codes": ["IAAB", "AAAA", "AAAB", "BAAA", "BAAB", "ccaa", "FAAB", "FAAA", "EAAA", "EAAB", "HAAA", "ceaa"]
                      }
                  ]
              }

--- a/custom_components/monitormysolar/coordinator.py
+++ b/custom_components/monitormysolar/coordinator.py
@@ -47,7 +47,11 @@ class MonitorMySolar(DataUpdateCoordinator[None]):
         self._dongle_ips: List[str] = entry.data.get("dongle_ips", [""] * len(self._dongle_ids))
         
         # Initialize per-dongle data structures
-        self._firmware_codes: Dict[str, str] = {dongle_id: None for dongle_id in self._dongle_ids}
+        # Load saved firmware codes from config entry
+        saved_firmware_codes = entry.data.get("firmware_codes", {})
+        self._firmware_codes: Dict[str, str] = {}
+        for dongle_id in self._dongle_ids:
+            self._firmware_codes[dongle_id] = saved_firmware_codes.get(dongle_id)
         self.entities: Dict[str, Any] = {}
         self.current_fw_versions: Dict[str, str] = {dongle_id: "" for dongle_id in self._dongle_ids}
         # self.current_ui_versions: Dict[str, str] = {dongle_id: "" for dongle_id in self._dongle_ids}  # Commented out - UI update entity removed
@@ -60,6 +64,12 @@ class MonitorMySolar(DataUpdateCoordinator[None]):
         self._max_history_entries = 100  # Limit history size per setting
         self._setup_errors = []  # Track errors during setup
         self._has_gridboss = entry.data.get("has_gridboss", False)  # Track if GridBoss is enabled
+        self._gridboss_dongle = entry.data.get("gridboss_dongle", "")  # Track which dongle is GridBoss
+        self._last_fault_warning_data = {}  # Track last fault/warning data to prevent duplicate processing
+        self._hass_startup_complete = False  # Track if Home Assistant has finished starting up
+        self._smart_soc_volt_bits = {}  # Track SmartSOCVoltBits for each dongle
+        self._smartload_bits = {}  # Track SmartLoad Bits for each dongle
+        self._port_modes = {}  # Track Port Mode settings for each dongle
 
         super().__init__(
             hass,
@@ -71,6 +81,7 @@ class MonitorMySolar(DataUpdateCoordinator[None]):
     def get_formatted_dongle_id(self, dongle_id: str) -> str:
         """Convert a dongle ID to the formatted version used in entity IDs."""
         return dongle_id.lower().replace("-", "_").replace(":", "_")
+    
 
     @property
     def inverter_brand(self) -> str:
@@ -81,10 +92,284 @@ class MonitorMySolar(DataUpdateCoordinator[None]):
     def has_gridboss(self) -> bool:
         """Check if GridBoss is enabled."""
         return self._has_gridboss
+    
+    def is_gridboss_dongle(self, dongle_id: str) -> bool:
+        """Check if a specific dongle is the GridBoss dongle."""
+        # First check if firmware code indicates GridBoss (IAAB)
+        firmware_code = self.get_firmware_code(dongle_id)
+        if firmware_code == "IAAB":
+            return True
+        
+        # If no firmware code yet, check config flow setting
+        if not self._has_gridboss or not self._gridboss_dongle:
+            return False
+        
+        # Map the gridboss_dongle setting to actual dongle ID
+        if self._gridboss_dongle == "dongle_id":
+            # First dongle
+            return dongle_id == self._dongle_ids[0] if self._dongle_ids else False
+        elif self._gridboss_dongle.startswith("dongle_id_"):
+            # Extract the index (dongle_id_2 = index 1, dongle_id_3 = index 2, etc.)
+            try:
+                index = int(self._gridboss_dongle.split("_")[-1]) - 1
+                return dongle_id == self._dongle_ids[index] if index < len(self._dongle_ids) else False
+            except (ValueError, IndexError):
+                return False
+        
+        return False
+    
+    def update_smart_soc_volt_bits(self, dongle_id: str, smart_soc_volt_bits: dict):
+        """Update the SmartSOCVoltBits settings for a dongle."""
+        old_bits = self._smart_soc_volt_bits.get(dongle_id, {})
+        self._smart_soc_volt_bits[dongle_id] = smart_soc_volt_bits
+        LOGGER.debug(f"Updated SmartSOCVoltBits for {dongle_id}: {smart_soc_volt_bits}")
+        
+        # If the bits changed, trigger entity updates
+        if old_bits != smart_soc_volt_bits:
+            self._trigger_entity_availability_update(dongle_id)
+    
+    def _trigger_entity_availability_update(self, dongle_id: str):
+        """Trigger entity availability updates for a dongle."""
+        # Don't trigger updates during startup
+        if not self._hass_startup_complete:
+            LOGGER.debug(f"Skipping entity availability update for {dongle_id} - HA startup not complete")
+            return
+        
+        # Add a small delay to allow MQTT responses to be processed first
+        # This prevents availability logic from blocking legitimate user actions
+        from homeassistant.helpers.event import async_call_later
+        async_call_later(self.hass, 2, self._async_update_entity_availability, dongle_id)
+    
+    async def _async_update_entity_availability(self, dongle_id: str):
+        """Update entity availability states."""
+        try:
+            # Simply trigger a single coordinator update to refresh entity availability
+            # The entities will check their availability in their available() property
+            self.async_set_updated_data(self.entities)
+            LOGGER.debug(f"Triggered entity availability update for {dongle_id}")
+        except Exception as e:
+            LOGGER.error(f"Error updating entity availability for {dongle_id}: {e}")
+    
+    def get_smart_soc_volt_bits(self, dongle_id: str) -> dict:
+        """Get the SmartSOCVoltBits settings for a dongle."""
+        return self._smart_soc_volt_bits.get(dongle_id, {})
+    
+    def is_smartload_soc_volt_enabled(self, dongle_id: str, smartload_number: int) -> bool:
+        """Check if a SmartLoad is configured to use SOC/Volt mode (True) or Time mode (False)."""
+        smart_soc_volt_bits = self.get_smart_soc_volt_bits(dongle_id)
+        key = f"SmartLoad{smartload_number}_SOC_Volt"
+        return smart_soc_volt_bits.get(key, False)
+    
+    def is_entity_available_for_smartload(self, dongle_id: str, entity_unique_id: str) -> bool:
+        """Check if an entity should be available based on SmartLoad SOC/Volt settings."""
+        if not self.is_gridboss_dongle(dongle_id):
+            return True  # Non-GridBoss entities are always available
+        
+        # Extract SmartLoad number from entity unique_id
+        smartload_number = None
+        if "SmartLoad1" in entity_unique_id:
+            smartload_number = 1
+        elif "SmartLoad2" in entity_unique_id:
+            smartload_number = 2
+        elif "SmartLoad3" in entity_unique_id:
+            smartload_number = 3
+        elif "SmartLoad4" in entity_unique_id:
+            smartload_number = 4
+        
+        if smartload_number is None:
+            return True  # Not a SmartLoad entity
+        
+        # Check if this is a SOC/Volt related entity
+        soc_volt_entities = ["StartSOC", "EndSOC", "StartVolt", "EndVolt", "SheddingStartSOC", "SheddingEndSOC", "SheddingStartVolt", "SheddingEndVolt"]
+        time_entities = ["Start0", "End0", "Start1", "End1", "Start2", "End2"]
+        
+        is_soc_volt_entity = any(suffix in entity_unique_id for suffix in soc_volt_entities)
+        is_time_entity = any(suffix in entity_unique_id for suffix in time_entities)
+        
+        if is_soc_volt_entity:
+            # SOC/Volt entities are available only when SmartLoad is in SOC/Volt mode
+            return self.is_smartload_soc_volt_enabled(dongle_id, smartload_number)
+        elif is_time_entity:
+            # Time entities are available only when SmartLoad is in Time mode
+            return not self.is_smartload_soc_volt_enabled(dongle_id, smartload_number)
+        
+        return True  # Other entities are always available
+    
+    def update_smartload_bits(self, dongle_id: str, smartload_bits: dict):
+        """Update the SmartLoad Bits settings for a dongle."""
+        old_bits = self._smartload_bits.get(dongle_id, {})
+        self._smartload_bits[dongle_id] = smartload_bits
+        LOGGER.debug(f"Updated SmartLoad Bits for {dongle_id}: {smartload_bits}")
+        
+        # If the bits changed, trigger entity updates
+        if old_bits != smartload_bits:
+            self._trigger_entity_availability_update(dongle_id)
+    
+    def get_smartload_bits(self, dongle_id: str) -> dict:
+        """Get the SmartLoad Bits settings for a dongle."""
+        return self._smartload_bits.get(dongle_id, {})
+    
+    def update_port_modes(self, dongle_id: str, port_modes: dict):
+        """Update the Port Mode settings for a dongle."""
+        old_modes = self._port_modes.get(dongle_id, {})
+        self._port_modes[dongle_id] = port_modes
+        LOGGER.debug(f"Updated Port Modes for {dongle_id}: {port_modes}")
+        
+        # If the modes changed, trigger entity updates
+        if old_modes != port_modes:
+            self._trigger_entity_availability_update(dongle_id)
+    
+    def get_port_modes(self, dongle_id: str) -> dict:
+        """Get the Port Mode settings for a dongle."""
+        return self._port_modes.get(dongle_id, {})
+    
+    def get_smartload_port_mode(self, dongle_id: str, smartload_number: int) -> int:
+        """Get the Port Mode for a specific SmartLoad (0=Does Not Operate, 1=Smart Load, 2=AC Coupled)."""
+        port_modes = self.get_port_modes(dongle_id)
+        key = f"SmartLoad{smartload_number}_PortMode"  # The payload uses "SmartLoad1_PortMode", "SmartLoad2_PortMode", etc.
+        return port_modes.get(key, 0)  # Default to "Does Not Operate"
+    
+    def is_smartload_enabled(self, dongle_id: str, smartload_number: int) -> bool:
+        """Check if a SmartLoad is enabled."""
+        smartload_bits = self.get_smartload_bits(dongle_id)
+        key = f"SmartLoad{smartload_number}_Enable"
+        return smartload_bits.get(key, False)
+    
+    def is_entity_available_for_smartload_enable(self, dongle_id: str, entity_unique_id: str) -> bool:
+        """Check if an entity should be available based on Port Mode, SOC/Volt settings, and SmartLoad enable state."""
+        if not self.is_gridboss_dongle(dongle_id):
+            return True  # Non-GridBoss entities are always available
+        
+        # Extract SmartLoad number from entity unique_id
+        smartload_number = None
+        if "SmartLoad1" in entity_unique_id:
+            smartload_number = 1
+        elif "SmartLoad2" in entity_unique_id:
+            smartload_number = 2
+        elif "SmartLoad3" in entity_unique_id:
+            smartload_number = 3
+        elif "SmartLoad4" in entity_unique_id:
+            smartload_number = 4
+        
+        # Check if this is a Port Mode select entity - these are always available
+        if "PortMode" in entity_unique_id:
+            return True
+        
+        # Check if this is a SOC/Volt mode select entity - available when Port Mode is Smart Load or AC Coupled
+        if "SOC_Volt" in entity_unique_id:
+            port_mode = self.get_smartload_port_mode(dongle_id, smartload_number)
+            if port_mode in [1, 2]:  # Smart Load or AC Coupled mode
+                LOGGER.debug(f"Entity {entity_unique_id}: SOC/Volt mode select, Port Mode={port_mode}, available")
+                return True
+            else:
+                LOGGER.debug(f"Entity {entity_unique_id}: SOC/Volt mode select, Port Mode={port_mode}, not available")
+                return False
+        
+        # If it's not a SmartLoad entity and not a Port Mode select, check if it's AC Coupled
+        if smartload_number is None:
+            # Check if this is an AC Coupled entity
+            if "ACcouple" in entity_unique_id:
+                # Extract AC Couple number
+                ac_couple_number = None
+                if "ACcouple1" in entity_unique_id:
+                    ac_couple_number = 1
+                elif "ACcouple2" in entity_unique_id:
+                    ac_couple_number = 2
+                elif "ACcouple3" in entity_unique_id:
+                    ac_couple_number = 3
+                elif "ACcouple4" in entity_unique_id:
+                    ac_couple_number = 4
+                
+                if ac_couple_number is not None:
+                    # AC Coupled entities are only available if the corresponding SmartLoad is in AC Coupled mode
+                    port_mode = self.get_smartload_port_mode(dongle_id, ac_couple_number)
+                    return port_mode == 2  # Only available if Port Mode is AC Coupled
+                else:
+                    return True  # Generic AC Coupled entity
+            else:
+                return True  # Not a SmartLoad or AC Coupled entity (like Generator, etc.)
+        
+        # Step 1: Check Port Mode first
+        port_mode = self.get_smartload_port_mode(dongle_id, smartload_number)
+        LOGGER.debug(f"Entity {entity_unique_id}: SmartLoad{smartload_number} Port Mode={port_mode}")
+        
+        # If Port Mode is "Does Not Operate" (0), no entities are available
+        if port_mode == 0:
+            LOGGER.debug(f"Entity {entity_unique_id}: Port Mode=0, entity not available")
+            return False
+        
+        # Step 2: Check entity type based on Port Mode
+        if port_mode == 1:  # Smart Load mode
+            # Smart Load entities are available
+            if "SmartLoad" in entity_unique_id and "ACcouple" not in entity_unique_id:
+                # Step 3: Check SOC/Volt vs Time mode for Smart Load entities
+                if self._is_soc_volt_entity(entity_unique_id):
+                    soc_volt_enabled = self.is_smartload_soc_volt_enabled(dongle_id, smartload_number)
+                    LOGGER.debug(f"Entity {entity_unique_id}: Port Mode=1, SOC/Volt entity, SOC/Volt enabled={soc_volt_enabled}")
+                    return soc_volt_enabled
+                elif self._is_time_entity(entity_unique_id):
+                    time_enabled = not self.is_smartload_soc_volt_enabled(dongle_id, smartload_number)
+                    LOGGER.debug(f"Entity {entity_unique_id}: Port Mode=1, Time entity, Time enabled={time_enabled}")
+                    return time_enabled
+                else:
+                    # Enable/Disable switches are always available when Port Mode is Smart Load
+                    if "Enable" in entity_unique_id:
+                        LOGGER.debug(f"Entity {entity_unique_id}: Port Mode=1, Enable switch, always available")
+                        return True
+                    # Other entities are available if SmartLoad is enabled
+                    smartload_enabled = self.is_smartload_enabled(dongle_id, smartload_number)
+                    LOGGER.debug(f"Entity {entity_unique_id}: Port Mode=1, Other entity, SmartLoad enabled={smartload_enabled}")
+                    return smartload_enabled
+            LOGGER.debug(f"Entity {entity_unique_id}: Port Mode=1, but not a SmartLoad entity")
+            return False
+            
+        elif port_mode == 2:  # AC Coupled mode
+            # AC Coupled entities are available
+            if "ACcouple" in entity_unique_id:
+                # AC Coupled enable switches are always available when Port Mode is AC Coupled
+                if "Enable" in entity_unique_id:
+                    LOGGER.debug(f"Entity {entity_unique_id}: Port Mode=2, AC Coupled Enable switch, always available")
+                    return True
+                # Other AC Coupled entities are available
+                LOGGER.debug(f"Entity {entity_unique_id}: Port Mode=2, AC Coupled entity, available")
+                return True
+            return False
+        
+        return False
+    
+    def _is_soc_volt_entity(self, entity_unique_id: str) -> bool:
+        """Check if an entity is SOC/Volt related."""
+        soc_volt_entities = ["StartSOC", "EndSOC", "StartVolt", "EndVolt", "SheddingStartSOC", "SheddingEndSOC", "SheddingStartVolt", "SheddingEndVolt"]
+        return any(entity in entity_unique_id for entity in soc_volt_entities)
+    
+    def _is_time_entity(self, entity_unique_id: str) -> bool:
+        """Check if an entity is time related."""
+        time_entities = ["Start0", "End0", "Start1", "End1", "Start2", "End2", "StartMinute", "EndMinute"]
+        return any(entity in entity_unique_id for entity in time_entities)
+    
+    def is_entity_available_for_smartload(self, dongle_id: str, entity_unique_id: str) -> bool:
+        """Check if an entity should be available based on Port Mode, SOC/Volt settings, and SmartLoad enable state."""
+        # Use the new hierarchical availability logic
+        return self.is_entity_available_for_smartload_enable(dongle_id, entity_unique_id)
 
     def get_firmware_code(self, dongle_id: str) -> str:
         """Get firmware code for a specific dongle."""
         return self._firmware_codes.get(dongle_id)
+    
+    async def save_firmware_code(self, dongle_id: str, firmware_code: str):
+        """Save firmware code to config entry data."""
+        if self._firmware_codes.get(dongle_id) != firmware_code:
+            self._firmware_codes[dongle_id] = firmware_code
+            
+            # Update config entry data
+            current_data = self.entry.data.copy()
+            if "firmware_codes" not in current_data:
+                current_data["firmware_codes"] = {}
+            current_data["firmware_codes"][dongle_id] = firmware_code
+            
+            # Update the config entry
+            self.hass.config_entries.async_update_entry(self.entry, data=current_data)
+            LOGGER.info(f"Saved firmware code {firmware_code} for dongle {dongle_id}")
     
     def get_dongle_ip(self, dongle_id: str) -> str:
         """Get IP address for a specific dongle."""
@@ -163,20 +448,28 @@ class MonitorMySolar(DataUpdateCoordinator[None]):
             dongle_id = topic.split('/')[0]
             #LOGGER.debug(f"Received MQTT message on topic {topic} from dongle {dongle_id}")
             
+            # Always process firmware code responses as they're needed for setup
             if topic.endswith("/firmwarecode/response"):
                 await self._handle_firmware_code_response(dongle_id, msg)
-            elif topic.endswith("/response"):
-                await self.mqtt_handler.response_received(msg)
-            elif topic.endswith("/status"):
-                await self.process_status_message(dongle_id, msg.payload)
+            # Skip other message processing during startup to prevent excessive updates
+            elif not self._hass_startup_complete:
+                # Just store the message for later processing if needed
+                pass
             else:
-                await self.process_message(dongle_id, topic, msg.payload)
-                
-            self.async_set_updated_data(self.entities)
+                # Process messages normally after startup is complete
+                if topic.endswith("/response"):
+                    await self.mqtt_handler.response_received(msg)
+                elif topic.endswith("/status"):
+                    await self.process_status_message(dongle_id, msg.payload)
+                else:
+                    await self.process_message(dongle_id, topic, msg.payload)
+                    
+                self.async_set_updated_data(self.entities)
         except Exception as e:
             LOGGER.error(f"Error processing MQTT message on topic {topic}: {e}")
-            # Still try to update data even if we encounter an error
-            self.async_set_updated_data(self.entities)
+            # Only update data after startup is complete
+            if self._hass_startup_complete:
+                self.async_set_updated_data(self.entities)
 
     async def _handle_firmware_code_response(self, dongle_id: str, msg) -> None:
         """Handle firmware code response."""
@@ -193,6 +486,12 @@ class MonitorMySolar(DataUpdateCoordinator[None]):
             if firmware_code:
                 self._firmware_codes[dongle_id] = firmware_code
                 LOGGER.debug(f"Firmware code received for {dongle_id}: {firmware_code}")
+                
+                # Save the firmware code to config entry
+                await self.save_firmware_code(dongle_id, firmware_code)
+                
+                # Create entities for this dongle now that we have the firmware code
+                await self._create_entities_for_dongle(dongle_id)
                 
                 # Check if this completes our setup for all dongles
                 if dongle_id in self._pending_dongles:
@@ -214,6 +513,83 @@ class MonitorMySolar(DataUpdateCoordinator[None]):
         
         # Update coordinator data to trigger any listeners
         self.async_set_updated_data(self.entities)
+    
+    def _process_gridboss_nested_data(self, dongle_id: str, payload_data):
+        """Process GridBoss nested payload structure - now simplified since payload has correct entity names."""
+        formatted_dongle_id = self.get_formatted_dongle_id(dongle_id)
+        
+        # Recursively process all nested data, flattening it to match entity unique_ids
+        def flatten_nested_data(data, prefix=""):
+            """Recursively flatten nested data structure."""
+            flattened = {}
+            for key, value in data.items():
+                if isinstance(value, dict):
+                    # Recursively process nested dictionaries
+                    nested_flattened = flatten_nested_data(value, prefix)
+                    flattened.update(nested_flattened)
+                else:
+                    # Direct key-value pair - use the key as-is since it now matches unique_id
+                    flattened[key] = value
+            return flattened
+        
+        # Check for SmartSOCVoltBits in the payload and track it
+        if "SmartSOCVoltBits" in payload_data:
+            self.update_smart_soc_volt_bits(dongle_id, payload_data["SmartSOCVoltBits"])
+        
+        # Check for SmartLoad Bits in the payload and track it
+        if "SmartLoad" in payload_data and "Bits" in payload_data["SmartLoad"]:
+            self.update_smartload_bits(dongle_id, payload_data["SmartLoad"]["Bits"])
+        
+        # Check for Port Mode settings in the payload and track it
+        if "MIDBox_SmartPortModeStruct" in payload_data:
+            # Store Port Mode data as-is without flattening (it already has correct keys)
+            port_mode_data = payload_data["MIDBox_SmartPortModeStruct"]
+            self.update_port_modes(dongle_id, port_mode_data)
+        
+        # Flatten the entire payload structure
+        flattened_data = flatten_nested_data(payload_data)
+        
+        # Process each flattened item
+        for entity_id_suffix, state in flattened_data.items():
+            # Skip if we've already handled these keys
+            if entity_id_suffix in ("SW_VERSION", "UI_VERSION"):
+                continue
+                
+            formatted_entity_id_suffix = entity_id_suffix.lower().replace("-", "_").replace(":", "_")
+            entity_type = self.determine_entity_type(formatted_entity_id_suffix)
+            entity_id = f"{entity_type}.{formatted_dongle_id}_{formatted_entity_id_suffix}"
+            self.entities[entity_id] = state
+
+    async def _create_entities_for_dongle(self, dongle_id: str):
+        """Create entities for a specific dongle after firmware code is received."""
+        formatted_dongle_id = self.get_formatted_dongle_id(dongle_id)
+        is_gridboss = self.is_gridboss_dongle(dongle_id)
+        
+        # Get brand entities
+        brand_entities = ENTITIES.get(self.inverter_brand, {})
+        if not brand_entities:
+            LOGGER.error(f"No entities defined for inverter brand: {self.inverter_brand}")
+            return
+        
+        entities_created = 0
+        for entityTypeName, entityTypes in brand_entities.items():
+            for typeName, entities in entityTypes.items():
+                for entity in entities:
+                    # For GridBoss dongles, only create GridBoss-specific entities
+                    if is_gridboss and not typeName.startswith("gridboss_"):
+                        continue
+                    # For non-GridBoss dongles, skip GridBoss-specific entities
+                    elif not is_gridboss and typeName.startswith("gridboss_"):
+                        continue
+                        
+                    entity_id: str = f"{entityTypeName}.{formatted_dongle_id}_{entity['unique_id'].lower()}"
+                    self.entities[entity_id] = None
+                    entities_created += 1
+        
+        LOGGER.info(f"Created {entities_created} entities for dongle {dongle_id} (GridBoss: {is_gridboss}, Firmware: {self.get_firmware_code(dongle_id)})")
+        
+        # Update coordinator data
+        self.async_set_updated_data(self.entities)
 
     @callback
     async def async_setup(self):
@@ -228,14 +604,8 @@ class MonitorMySolar(DataUpdateCoordinator[None]):
             LOGGER.error(f"No entities defined for inverter brand: {self.inverter_brand}")
             return False
 
-        # Set up entities dictionary for each dongle
-        for dongle_id in self._dongle_ids:
-            formatted_dongle_id = self.get_formatted_dongle_id(dongle_id)
-            for entityTypeName, entityTypes in brand_entities.items():
-                for typeName, entities in entityTypes.items():
-                    for entity in entities:
-                        entity_id: str = f"{entityTypeName}.{formatted_dongle_id}_{entity['unique_id'].lower()}"
-                        self.entities[entity_id] = None
+        # Don't create entities yet - wait for firmware codes to determine entity types
+        # Entities will be created in _recreate_entities_for_dongle() after firmware codes are received
 
         # Request firmware codes for all dongles
         await self.request_firmware_codes()
@@ -243,34 +613,58 @@ class MonitorMySolar(DataUpdateCoordinator[None]):
         # Set up update listener
         self.entry.async_on_unload(self.entry.add_update_listener(self.config_entry_update_listener))
         
+        # Schedule startup completion after a delay to allow Home Assistant to finish starting up
+        async def mark_startup_complete(_):
+            self._hass_startup_complete = True
+            LOGGER.info("Home Assistant startup complete - MQTT message processing enabled")
+            
+            # Trigger entity availability updates for all dongles now that startup is complete
+            for dongle_id in self._dongle_ids:
+                if self.is_gridboss_dongle(dongle_id):
+                    self._trigger_entity_availability_update(dongle_id)
+        
+        # Wait 30 seconds after setup to allow Home Assistant to finish starting up
+        async_call_later(self.hass, 30, mark_startup_complete)
+        
         return True
 
     async def request_firmware_codes(self):
-        """Request firmware codes for all dongles."""
-        LOGGER.debug(f"Requesting firmware codes for {len(self._dongle_ids)} dongles")
+        """Request firmware codes for dongles that don't have them saved."""
+        dongles_needing_firmware = [dongle_id for dongle_id in self._dongle_ids if not self._firmware_codes.get(dongle_id)]
         
-        # Request firmware codes for all dongles
-        for dongle_id in self._dongle_ids:
-            if not self._firmware_codes.get(dongle_id):
-                LOGGER.debug(f"Requesting firmware code for dongle {dongle_id}...")
-                firmware_topic = f"{dongle_id}/firmwarecode/response"
+        if not dongles_needing_firmware:
+            LOGGER.info("All firmware codes already saved, proceeding with entity creation")
+            await self._create_entities_for_all_dongles()
+            return
+        
+        LOGGER.debug(f"Requesting firmware codes for {len(dongles_needing_firmware)} dongles (already have {len(self._dongle_ids) - len(dongles_needing_firmware)})")
+        
+        # Request firmware codes only for dongles that don't have them
+        for dongle_id in dongles_needing_firmware:
+            LOGGER.debug(f"Requesting firmware code for dongle {dongle_id}...")
+            firmware_topic = f"{dongle_id}/firmwarecode/response"
+            
+            try:
+                # Subscribe to firmware code response for this dongle
+                unsubscribe_callback = await mqtt.async_subscribe(
+                    self.hass, firmware_topic, self._async_handle_mqtt_message
+                )
                 
-                try:
-                    # Subscribe to firmware code response for this dongle
-                    unsubscribe_callback = await mqtt.async_subscribe(
-                        self.hass, firmware_topic, self._async_handle_mqtt_message
-                    )
-                    
-                    self._mqtt_unsubscribe_callbacks[f"{dongle_id}_firmware"] = unsubscribe_callback
-                    LOGGER.debug(f"Successfully subscribed to {firmware_topic}")
-                    
-                    # Publish request for firmware code
-                    await mqtt.async_publish(
-                        self.hass, f"{dongle_id}/firmwarecode/request", ""
-                    )
-                    LOGGER.debug(f"Published firmware code request to {dongle_id}/firmwarecode/request")
-                except Exception as e:
-                    LOGGER.error(f"Error setting up MQTT for dongle {dongle_id}: {e}")
+                self._mqtt_unsubscribe_callbacks[f"{dongle_id}_firmware"] = unsubscribe_callback
+                LOGGER.debug(f"Successfully subscribed to {firmware_topic}")
+                
+                # Publish request for firmware code
+                await mqtt.async_publish(
+                    self.hass, f"{dongle_id}/firmwarecode/request", ""
+                )
+                LOGGER.debug(f"Published firmware code request to {dongle_id}/firmwarecode/request")
+            except Exception as e:
+                LOGGER.error(f"Error setting up MQTT for dongle {dongle_id}: {e}")
+        
+        # Log which dongles already have firmware codes
+        for dongle_id in self._dongle_ids:
+            if self._firmware_codes.get(dongle_id):
+                LOGGER.debug(f"Firmware code already saved for dongle {dongle_id}: {self._firmware_codes[dongle_id]}")
 
         # Log all active subscriptions to verify
         LOGGER.debug(f"Active MQTT subscriptions: {list(self._mqtt_unsubscribe_callbacks.keys())}")
@@ -281,7 +675,14 @@ class MonitorMySolar(DataUpdateCoordinator[None]):
                 LOGGER.error(f"Firmware code responses not received for dongles: {self._pending_dongles}")
                 # Log active subscriptions for diagnostic purposes
                 LOGGER.debug(f"Current active MQTT subscriptions: {list(self._mqtt_unsubscribe_callbacks.keys())}")
-                # We don't reauth here anymore, as we'll still try to set up what we can
+                
+                # Create default entities for dongles that didn't respond (assume regular inverter)
+                for dongle_id in self._pending_dongles:
+                    LOGGER.warning(f"Creating default entities for dongle {dongle_id} (no firmware code received)")
+                    await self._create_entities_for_dongle(dongle_id)
+                
+                # Clear pending dongles
+                self._pending_dongles.clear()
                 
         async_call_later(self.hass, 15, firmware_timeout)
         
@@ -321,12 +722,14 @@ class MonitorMySolar(DataUpdateCoordinator[None]):
                 )
                 LOGGER.debug(f"Subscribed to all MQTT topics for {dongle_id} with pattern {topic_pattern}")
                 
-                # If GridBoss is enabled, subscribe to GridBoss specific topics
-                if self._has_gridboss:
+                # If this is a GridBoss dongle, subscribe to GridBoss specific topics
+                if self.is_gridboss_dongle(dongle_id):
                     gridboss_topics = [
                         f"{dongle_id}/gridboss_inputbank1",
                         f"{dongle_id}/gridboss_inputbank2",
-                        f"{dongle_id}/gridboss_holdbank1"
+                        f"{dongle_id}/gridboss_holdbank1",
+                        f"{dongle_id}/gridboss_holdbank2",
+                        f"{dongle_id}/gridboss_holdbank3"
                     ]
                     
                     for topic in gridboss_topics:
@@ -400,6 +803,9 @@ class MonitorMySolar(DataUpdateCoordinator[None]):
         formatted_dongle_id = self.get_formatted_dongle_id(dongle_id)
         entity_id = f"sensor.{formatted_dongle_id}_uptime"
         self.entities[entity_id] = status_data
+        
+        # Don't update coordinator data for status messages - they're too frequent
+        # The main message processing will handle coordinator updates
 
     async def process_message(self, dongle_id: str, topic, payload):
         """Process incoming MQTT message and update entity states."""
@@ -457,56 +863,76 @@ class MonitorMySolar(DataUpdateCoordinator[None]):
 
         # Process fault data
         if fault_data:
-            LOGGER.debug(f"Processing fault data for {dongle_id}: {fault_data}")
-            fault_value = fault_data.get("value", 0)
-            entity_id = f"sensor.{formatted_dongle_id}_fault_status"
-
-            if fault_value == 0:
-                self.entities[entity_id] = {
-                    "value": 0,
-                    "description": None  # This will trigger "No Fault" state
-                }
+            # Check if this fault data is the same as the last one to prevent duplicate processing
+            fault_key = f"{dongle_id}_fault"
+            if fault_key in self._last_fault_warning_data and self._last_fault_warning_data[fault_key] == fault_data:
+                # Skip duplicate fault data
+                pass
             else:
-                descriptions = fault_data.get("descriptions", ["Unknown Fault"])
-                timestamp = fault_data.get("timestamp", "Unknown")
-                self.entities[entity_id] = {
-                    "value": fault_value,
-                    "description": ", ".join(descriptions),
-                    "start_time": timestamp,
-                    "end_time": "Ongoing"
-                }
+                LOGGER.debug(f"Processing fault data for {dongle_id}: {fault_data}")
+                self._last_fault_warning_data[fault_key] = fault_data
+                fault_value = fault_data.get("value", 0)
+                entity_id = f"sensor.{formatted_dongle_id}_fault_status"
+
+                if fault_value == 0:
+                    self.entities[entity_id] = {
+                        "value": 0,
+                        "description": None  # This will trigger "No Fault" state
+                    }
+                else:
+                    descriptions = fault_data.get("descriptions", ["Unknown Fault"])
+                    timestamp = fault_data.get("timestamp", "Unknown")
+                    self.entities[entity_id] = {
+                        "value": fault_value,
+                        "description": ", ".join(descriptions),
+                        "start_time": timestamp,
+                        "end_time": "Ongoing"
+                    }
 
         # Process warning data
         if warning_data:
-            LOGGER.debug(f"Processing warning data for {dongle_id}: {warning_data}")
-            warning_value = warning_data.get("value", 0)
-            entity_id = f"sensor.{formatted_dongle_id}_warning_status"
-
-            if warning_value == 0:
-                self.entities[entity_id] = {
-                    "value": 0,
-                    "description": None  # This will trigger "No Warning" state
-                }
+            # Check if this warning data is the same as the last one to prevent duplicate processing
+            warning_key = f"{dongle_id}_warning"
+            if warning_key in self._last_fault_warning_data and self._last_fault_warning_data[warning_key] == warning_data:
+                # Skip duplicate warning data
+                pass
             else:
-                descriptions = warning_data.get("descriptions", ["Unknown Warning"])
-                timestamp = warning_data.get("timestamp", "Unknown")
-                self.entities[entity_id] = {
-                    "value": warning_value,
-                    "description": ", ".join(descriptions),
-                    "start_time": timestamp,
-                    "end_time": "Ongoing"
-                }
+                LOGGER.debug(f"Processing warning data for {dongle_id}: {warning_data}")
+                self._last_fault_warning_data[warning_key] = warning_data
+                warning_value = warning_data.get("value", 0)
+                entity_id = f"sensor.{formatted_dongle_id}_warning_status"
+
+                if warning_value == 0:
+                    self.entities[entity_id] = {
+                        "value": 0,
+                        "description": None  # This will trigger "No Warning" state
+                    }
+                else:
+                    descriptions = warning_data.get("descriptions", ["Unknown Warning"])
+                    timestamp = warning_data.get("timestamp", "Unknown")
+                    self.entities[entity_id] = {
+                        "value": warning_value,
+                        "description": ", ".join(descriptions),
+                        "start_time": timestamp,
+                        "end_time": "Ongoing"
+                    }
                 
         # Process main sensor data - now with more efficient entity type determination
-        for entity_id_suffix, state in payload_data.items():
-            # Skip if we've already handled these keys
-            if entity_id_suffix in ("SW_VERSION", "UI_VERSION"):
-                continue
-                
-            formatted_entity_id_suffix = entity_id_suffix.lower().replace("-", "_").replace(":", "_")
-            entity_type = self.determine_entity_type(formatted_entity_id_suffix)
-            entity_id = f"{entity_type}.{formatted_dongle_id}_{formatted_entity_id_suffix}"
-            self.entities[entity_id] = state
+        # For GridBoss, we need to handle the nested structure properly
+        if self.is_gridboss_dongle(dongle_id):
+            # Process GridBoss nested structure correctly
+            self._process_gridboss_nested_data(dongle_id, payload_data)
+        else:
+            # Process regular inverter data
+            for entity_id_suffix, state in payload_data.items():
+                # Skip if we've already handled these keys
+                if entity_id_suffix in ("SW_VERSION", "UI_VERSION"):
+                    continue
+                    
+                formatted_entity_id_suffix = entity_id_suffix.lower().replace("-", "_").replace(":", "_")
+                entity_type = self.determine_entity_type(formatted_entity_id_suffix)
+                entity_id = f"{entity_type}.{formatted_dongle_id}_{formatted_entity_id_suffix}"
+                self.entities[entity_id] = state
             
         # Process events data if present (new format)
         if events_data:
@@ -518,6 +944,10 @@ class MonitorMySolar(DataUpdateCoordinator[None]):
                 formatted_event_id = event_id.lower().replace("-", "_").replace(":", "_")
                 entity_id = f"binary_sensor.{formatted_dongle_id}_{formatted_event_id}"
                 self.entities[entity_id] = event_state
+        
+        # Update coordinator data after processing all entities
+        self.async_set_updated_data(self.entities)
+    
 
     def determine_entity_type(self, entity_id_suffix):
         """Determine the entity type based on the entity_id_suffix."""

--- a/custom_components/monitormysolar/manifest.json
+++ b/custom_components/monitormysolar/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/Monitor-My-Solar/monitormysolar",
   "loggers": [],
   "requirements": [],    
-  "version": "3.0.4"
+  "version": "3.0.5"
 }
 

--- a/custom_components/monitormysolar/mqttHandeler.py
+++ b/custom_components/monitormysolar/mqttHandeler.py
@@ -5,7 +5,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.components.mqtt import async_publish
 from homeassistant.components import mqtt
 
-from .const import DOMAIN, LOGGER
+from .const import DOMAIN, LOGGER, ENTITIES
 
 class MQTTHandler:
     def __init__(self, hass: HomeAssistant):
@@ -51,6 +51,8 @@ class MQTTHandler:
         modified_dongle_id[1] = modified_dongle_id[1].upper()
         modified_dongle_id = "-".join(modified_dongle_id)
 
+        # All settings (including GridBoss settings) should be sent to the /update topic
+        # GridBoss bank topics are only for reading data, not for sending updates
         topic = f"{modified_dongle_id}/update"
         
         # Updated payload with setting, value, and from: homeassistant
@@ -140,7 +142,16 @@ class MQTTHandler:
                     modified_dongle_id[1] = modified_dongle_id[1].upper()
                     modified_dongle_id = "-".join(modified_dongle_id)
                     
-                    topic = f"{modified_dongle_id}/update"
+                    # Check if this is a GridBoss setting
+                    is_gridboss_setting = self._is_gridboss_setting(unique_id)
+                    
+                    if is_gridboss_setting:
+                        # For GridBoss settings, we need to determine the correct bank
+                        bank = self._get_gridboss_bank(unique_id)
+                        topic = f"{modified_dongle_id}/gridboss_{bank}"
+                    else:
+                        topic = f"{modified_dongle_id}/update"
+                    
                     payload = json.dumps({
                         "setting": unique_id,
                         "value": value,
@@ -267,6 +278,9 @@ class MQTTHandler:
                 LOGGER.info(f"Successfully updated state of entity {entity.entity_id}.")
                 # Keep the current state as it was already optimistically updated
                 self.hass.loop.call_soon_threadsafe(entity.async_write_ha_state)
+                # Clear user-initiated flag for select entities
+                if hasattr(entity, 'clear_user_initiated_flag'):
+                    self.hass.loop.call_soon_threadsafe(entity.clear_user_initiated_flag)
             else:
                 LOGGER.error(f"Failed to update state for {entity.entity_id}, reverting state.")
                 self.hass.loop.call_soon_threadsafe(entity.revert_state)
@@ -312,6 +326,8 @@ class MQTTHandler:
         modified_dongle_id[1] = modified_dongle_id[1].upper()
         modified_dongle_id = "-".join(modified_dongle_id)
 
+        # All settings (including GridBoss settings) should be sent to the /update topic
+        # GridBoss bank topics are only for reading data, not for sending updates
         topic = f"{modified_dongle_id}/update"
         
         # Create payload with multiple settings
@@ -327,7 +343,7 @@ class MQTTHandler:
             "from": "homeassistant"
         })
         
-        LOGGER.info(f"Sending multiple MQTT updates: {topic} - {payload} at {datetime.now()}")
+        LOGGER.info(f"Sending MQTT update: {topic} - {payload} at {datetime.now()}")
         await mqtt.async_publish(self.hass, topic, payload)
 
         self.response_received_event.clear()
@@ -343,3 +359,28 @@ class MQTTHandler:
             LOGGER.error(f"No response received for {entity.entity_id} within the timeout period.")
             self.hass.loop.call_soon_threadsafe(entity.revert_state)
             return False
+    
+    def _is_gridboss_setting(self, unique_id):
+        """Check if a setting is a GridBoss setting by looking at the ENTITIES definition."""
+        # Look through all entity types and banks to find if this unique_id is in a gridboss bank
+        for entity_type, banks in ENTITIES.get("Lux", {}).items():
+            for bank_name, entities in banks.items():
+                if bank_name.startswith("gridboss_"):
+                    for entity in entities:
+                        if entity.get("unique_id") == unique_id:
+                            return True
+        return False
+    
+    def _get_gridboss_bank(self, unique_id):
+        """Get the GridBoss bank name for a given unique_id."""
+        # Look through all entity types and banks to find which gridboss bank this unique_id belongs to
+        for entity_type, banks in ENTITIES.get("Lux", {}).items():
+            for bank_name, entities in banks.items():
+                if bank_name.startswith("gridboss_"):
+                    for entity in entities:
+                        if entity.get("unique_id") == unique_id:
+                            # Extract the bank part (e.g., "holdbank1" from "gridboss_holdbank1")
+                            return bank_name.replace("gridboss_", "")
+        
+        # Default fallback
+        return "holdbank1"

--- a/custom_components/monitormysolar/number.py
+++ b/custom_components/monitormysolar/number.py
@@ -28,6 +28,11 @@ async def async_setup_entry(hass, entry: MonitorMySolarEntry, async_add_entities
     for dongle_id in dongle_ids:
         firmware_code = coordinator.get_firmware_code(dongle_id)
         
+        # Only create entities if we have a firmware code
+        if not firmware_code:
+            LOGGER.debug(f"Skipping entity creation for {dongle_id} - no firmware code available yet")
+            continue
+        
         # Process numbers for this dongle
         for bank_name, numbers in number_config.items():
             # Skip combined numbers for individual dongles
@@ -36,13 +41,23 @@ async def async_setup_entry(hass, entry: MonitorMySolarEntry, async_add_entities
                 
             for number in numbers:
                 allowed_firmware_codes = number.get("allowed_firmware_codes", [])
-                if not allowed_firmware_codes or firmware_code in allowed_firmware_codes:
-                    try:
-                        entities.append(
-                            InverterNumber(number, hass, entry, bank_name, dongle_id)
-                        )
-                    except Exception as e:
-                        LOGGER.error(f"Error setting up number {number} for dongle {dongle_id}: {e}")
+                # For GridBoss dongles (IAAB), only create entities that explicitly allow this firmware code
+                if coordinator.is_gridboss_dongle(dongle_id):
+                    if not allowed_firmware_codes or firmware_code not in allowed_firmware_codes:
+                        continue
+                else:
+                    # For regular dongles, use the original logic
+                    if not allowed_firmware_codes or firmware_code in allowed_firmware_codes:
+                        pass  # Continue to entity creation
+                    else:
+                        continue  # Skip this entity
+                
+                try:
+                    entities.append(
+                        InverterNumber(number, hass, entry, bank_name, dongle_id)
+                    )
+                except Exception as e:
+                    LOGGER.error(f"Error setting up number {number} for dongle {dongle_id}: {e}")
                     
     # Create combined numbers if we have multiple dongles
     if len(dongle_ids) > 1 and "combined" in number_config:
@@ -83,12 +98,26 @@ class InverterNumber(MonitorMySolarEntity, NumberEntity):
         super().__init__(self.coordinator)
 
     @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        if not self.coordinator.last_update_success:
+            return False
+        
+        # Check if entity should be available based on SmartLoad SOC/Volt settings
+        return self.coordinator.is_entity_available_for_smartload(self._dongle_id, self._entity_type)
+    
+
+    @property
     def name(self):
         return self._attr_name
 
     async def async_set_native_value(self, value):
         """Set the number value."""
         LOGGER.debug(f"Setting value of number {self.entity_id} to {value}")
+        
+        # Allow the action to proceed - availability logic only affects UI display
+        # The MQTT handler will send the command regardless of availability
+        
         mqtt_handler = self.coordinator.mqtt_handler
         if mqtt_handler is not None:
             # Save the current value before changing

--- a/custom_components/monitormysolar/select.py
+++ b/custom_components/monitormysolar/select.py
@@ -24,18 +24,33 @@ async def async_setup_entry(hass, entry: MonitorMySolarEntry, async_add_entities
     for dongle_id in dongle_ids:
         firmware_code = coordinator.get_firmware_code(dongle_id)
         
+        # Only create entities if we have a firmware code
+        if not firmware_code:
+            LOGGER.debug(f"Skipping entity creation for {dongle_id} - no firmware code available yet")
+            continue
+        
         # Process selects for this dongle
         for bank_name, selects in select_config.items():
             for select in selects:
                 allowed_firmware_codes = select.get("allowed_firmware_codes", [])
-                if not allowed_firmware_codes or firmware_code in allowed_firmware_codes:
-                    try:
-                        if bank_name == "holdbank6":
-                            entities.append(QuickChargeDurationSelect(select, hass, entry, bank_name, dongle_id))
-                        else:
-                            entities.append(InverterSelect(select, hass, entry, dongle_id))
-                    except Exception as e:
-                        LOGGER.error(f"Error setting up select {select} for dongle {dongle_id}: {e}")
+                # For GridBoss dongles (IAAB), only create entities that explicitly allow this firmware code
+                if coordinator.is_gridboss_dongle(dongle_id):
+                    if not allowed_firmware_codes or firmware_code not in allowed_firmware_codes:
+                        continue
+                else:
+                    # For regular dongles, use the original logic
+                    if not allowed_firmware_codes or firmware_code in allowed_firmware_codes:
+                        pass  # Continue to entity creation
+                    else:
+                        continue  # Skip this entity
+                
+                try:
+                    if bank_name == "holdbank6":
+                        entities.append(QuickChargeDurationSelect(select, hass, entry, bank_name, dongle_id))
+                    else:
+                        entities.append(InverterSelect(select, hass, entry, dongle_id))
+                except Exception as e:
+                    LOGGER.error(f"Error setting up select {select} for dongle {dongle_id}: {e}")
 
     async_add_entities(entities, True)
 
@@ -81,13 +96,73 @@ class InverterSelect(MonitorMySolarEntity, SelectEntity):
     async def async_select_option(self, option):
         """Update the select option."""
         LOGGER.info(f"Setting select option for {self.entity_id} to {option}")
+        
+        # Store the previous state before changing
+        self._previous_state = self._state
         self._state = option
+        
+        # Set a flag to indicate this is a user-initiated change
+        self._user_initiated_change = True
+        
         self.throttled_async_write_ha_state()
-
-
 
         bit_value = self._options.index(option)
         LOGGER.info(f"Setting Select value for {self.entity_id} to {option}")
+        
+        # If this is a Port Mode change, trigger immediate availability update
+        if "PortMode" in self.entity_info["unique_id"]:
+            LOGGER.info(f"Port Mode changed to {option} (value: {bit_value}), triggering immediate availability update")
+            # Update the Port Mode data immediately for availability logic
+            smartload_number = None
+            if "SmartLoad1" in self.entity_info["unique_id"]:
+                smartload_number = 1
+            elif "SmartLoad2" in self.entity_info["unique_id"]:
+                smartload_number = 2
+            elif "SmartLoad3" in self.entity_info["unique_id"]:
+                smartload_number = 3
+            elif "SmartLoad4" in self.entity_info["unique_id"]:
+                smartload_number = 4
+            
+            if smartload_number is not None:
+                # Update the Port Mode data immediately
+                port_modes = self.coordinator.get_port_modes(self._dongle_id)
+                port_modes[f"SmartLoad{smartload_number}_PortMode"] = bit_value
+                self.coordinator.update_port_modes(self._dongle_id, port_modes)
+                
+                # Log what entities should become available
+                if bit_value == 1:  # Smart Load mode
+                    LOGGER.info(f"SmartLoad{smartload_number} set to Smart Load mode - SmartLoad{smartload_number} Enable switch and SOC/Volt mode select should become available")
+                elif bit_value == 2:  # AC Coupled mode
+                    LOGGER.info(f"SmartLoad{smartload_number} set to AC Coupled mode - AC Coupled{smartload_number} Enable switch and SOC/Volt mode select should become available")
+                elif bit_value == 0:  # Does Not Operate mode
+                    LOGGER.info(f"SmartLoad{smartload_number} set to Does Not Operate mode - all related entities should become unavailable")
+        
+        # If this is a SOC/Volt mode change, trigger immediate availability update
+        elif "SOC_Volt" in self.entity_info["unique_id"]:
+            LOGGER.info(f"SOC/Volt mode changed to {option} (value: {bit_value}), triggering immediate availability update")
+            # Update the SOC/Volt mode data immediately for availability logic
+            smartload_number = None
+            if "SmartLoad1" in self.entity_info["unique_id"]:
+                smartload_number = 1
+            elif "SmartLoad2" in self.entity_info["unique_id"]:
+                smartload_number = 2
+            elif "SmartLoad3" in self.entity_info["unique_id"]:
+                smartload_number = 3
+            elif "SmartLoad4" in self.entity_info["unique_id"]:
+                smartload_number = 4
+            
+            if smartload_number is not None:
+                # Update the SOC/Volt mode data immediately
+                soc_volt_bits = self.coordinator.get_smart_soc_volt_bits(self._dongle_id)
+                soc_volt_bits[f"SmartLoad{smartload_number}_SOC_Volt"] = bit_value == 1  # True for SOC/Volt, False for Time
+                self.coordinator.update_smart_soc_volt_bits(self._dongle_id, soc_volt_bits)
+                
+                # Log what entities should become available
+                if bit_value == 1:  # SOC/Volt mode
+                    LOGGER.info(f"SmartLoad{smartload_number} set to SOC/Volt mode - SOC/Volt entities should become available, Time entities should become unavailable")
+                elif bit_value == 0:  # Time mode
+                    LOGGER.info(f"SmartLoad{smartload_number} set to Time mode - Time entities should become available, SOC/Volt entities should become unavailable")
+        
         await self.coordinator.mqtt_handler.send_update(
             self._dongle_id,
             self.entity_info["unique_id"],
@@ -97,9 +172,21 @@ class InverterSelect(MonitorMySolarEntity, SelectEntity):
 
     def revert_state(self):
         """Revert to the previous state."""
-        LOGGER.info(f"Reverting state for {self.entity_id} to {self._state}")
-        # Schedule state revert on the main thread
-        self.hass.loop.call_soon_threadsafe(self.throttled_async_write_ha_state)
+        if hasattr(self, '_previous_state') and self._previous_state is not None:
+            LOGGER.info(f"Reverting state for {self.entity_id} from {self._state} to {self._previous_state}")
+            self._state = self._previous_state
+            # Clear the user-initiated flag since we're reverting
+            if hasattr(self, '_user_initiated_change'):
+                self._user_initiated_change = False
+            self.throttled_async_write_ha_state()
+        else:
+            LOGGER.warning(f"No previous state to revert to for {self.entity_id}")
+    
+    def clear_user_initiated_flag(self):
+        """Clear the user-initiated change flag when MQTT response is successful."""
+        if hasattr(self, '_user_initiated_change'):
+            LOGGER.debug(f"Select {self.entity_id}: Clearing user_initiated flag after successful MQTT response")
+            self._user_initiated_change = False
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -109,13 +196,46 @@ class InverterSelect(MonitorMySolarEntity, SelectEntity):
         if self.entity_id in self.coordinator.entities:
             value = self.coordinator.entities[self.entity_id]
             if value is not None:
-                self._state = (
-                    self._options[value]
-                    if isinstance(value, int) and value < len(self._options)
-                    else value
-                )
-                # Schedule state update on the main thread
-                self.hass.loop.call_soon_threadsafe(self.throttled_async_write_ha_state)
+                # Handle different value types for different select types
+                if "SOC_Volt" in self.entity_info["unique_id"]:
+                    # For SOC/Volt mode selects, value might be boolean (True/False) or int (0/1)
+                    if isinstance(value, bool):
+                        new_state = "SOC/Volt" if value else "Time"
+                    elif isinstance(value, int):
+                        new_state = self._options[value] if value < len(self._options) else value
+                    else:
+                        new_state = value
+                else:
+                    # For other selects (like Port Mode), value is typically int
+                    new_state = (
+                        self._options[value]
+                        if isinstance(value, int) and value < len(self._options)
+                        else value
+                    )
+                
+                # Debug logging to see what's happening
+                LOGGER.debug(f"Select {self.entity_id}: Coordinator update - current state: {self._state}, coordinator value: {value}, new state: {new_state}, user_initiated: {getattr(self, '_user_initiated_change', False)}")
+                
+                # If this is a user-initiated change, don't override it with coordinator data
+                # unless the coordinator data matches what the user selected
+                if hasattr(self, '_user_initiated_change') and self._user_initiated_change:
+                    if new_state == self._state:
+                        # Coordinator data matches user selection, clear the flag
+                        LOGGER.debug(f"Select {self.entity_id}: Coordinator data matches user selection, clearing user_initiated flag")
+                        self._user_initiated_change = False
+                    else:
+                        # Coordinator data doesn't match, this might be stale data
+                        LOGGER.warning(f"Select {self.entity_id}: Ignoring coordinator update during user-initiated change (coordinator: {new_state}, user: {self._state})")
+                        return
+                
+                # Only update if the state actually changed to prevent unnecessary updates
+                if new_state != self._state:
+                    LOGGER.info(f"Select {self.entity_id}: Updating state from {self._state} to {new_state} (coordinator value: {value})")
+                    self._state = new_state
+                    # Schedule state update on the main thread
+                    self.hass.loop.call_soon_threadsafe(self.throttled_async_write_ha_state)
+                else:
+                    LOGGER.debug(f"Select {self.entity_id}: No state change needed (already {self._state})")
 
 
 class QuickChargeDurationSelect(MonitorMySolarEntity, SelectEntity):

--- a/custom_components/monitormysolar/sensor.py
+++ b/custom_components/monitormysolar/sensor.py
@@ -51,6 +51,11 @@ async def async_setup_entry(hass, entry: MonitorMySolarEntry, async_add_entities
         firmware_code = coordinator.get_firmware_code(dongle_id)
         formatted_dongle_id = coordinator.get_formatted_dongle_id(dongle_id)
         
+        # Only create entities if we have a firmware code
+        if not firmware_code:
+            LOGGER.debug(f"Skipping entity creation for {dongle_id} - no firmware code available yet")
+            continue
+        
         # Loop through the sensors in the configuration for this dongle
         for bank_name, sensors in sensors_config.items():
             # Skip combined sensors for individual dongles
@@ -59,43 +64,53 @@ async def async_setup_entry(hass, entry: MonitorMySolarEntry, async_add_entities
                 
             for sensor in sensors:
                 allowed_firmware_codes = sensor.get("allowed_firmware_codes", [])
-                if not allowed_firmware_codes or firmware_code in allowed_firmware_codes:
-                    try:
-                        # Check if the sensor is of type 'status' to create the StatusSensor class
-                        if bank_name == "status":
-                            entities.append(
-                                StatusSensor(sensor, hass, entry, bank_name, dongle_id),
-                            )
-                        elif bank_name == "powerflow":
-                            entities.append(
-                                PowerFlowSensor(sensor, hass, entry, bank_name, dongle_id)
-                            )
-                        elif bank_name == "timestamp":
-                            entities.append(
-                                BankUpdateSensor(sensor, hass, entry, bank_name, dongle_id)
-                            )
-                        elif bank_name == "warning":
-                            entities.append(
-                                FaultWarningSensor(sensor, hass, entry, bank_name, dongle_id)
-                            )
-                        elif bank_name == "fault":
-                            entities.append(
-                                FaultWarningSensor(sensor, hass, entry, bank_name, dongle_id)
-                            )
-                        elif bank_name == "calculated":
-                            entities.append(
-                                CalculatedSensor(sensor, hass, entry, bank_name, dongle_id)
-                            )
-                        elif bank_name == "temperature":
-                            entities.append(
-                                TemperatureSensor(sensor, hass, entry, bank_name, dongle_id)
-                            )
-                        else:
-                            entities.append(
-                                InverterSensor(sensor, hass, entry, bank_name, dongle_id)
-                            )
-                    except Exception as e:
-                        LOGGER.error(f"Error setting up sensor {sensor} for dongle {dongle_id}: {e}")
+                # For GridBoss dongles (IAAB), only create entities that explicitly allow this firmware code
+                if coordinator.is_gridboss_dongle(dongle_id):
+                    if not allowed_firmware_codes or firmware_code not in allowed_firmware_codes:
+                        continue
+                else:
+                    # For regular dongles, use the original logic
+                    if not allowed_firmware_codes or firmware_code in allowed_firmware_codes:
+                        pass  # Continue to entity creation
+                    else:
+                        continue  # Skip this entity
+                
+                try:
+                    # Check if the sensor is of type 'status' to create the StatusSensor class
+                    if bank_name == "status":
+                        entities.append(
+                            StatusSensor(sensor, hass, entry, bank_name, dongle_id),
+                        )
+                    elif bank_name == "powerflow":
+                        entities.append(
+                            PowerFlowSensor(sensor, hass, entry, bank_name, dongle_id)
+                        )
+                    elif bank_name == "timestamp":
+                        entities.append(
+                            BankUpdateSensor(sensor, hass, entry, bank_name, dongle_id)
+                        )
+                    elif bank_name == "warning":
+                        entities.append(
+                            FaultWarningSensor(sensor, hass, entry, bank_name, dongle_id)
+                        )
+                    elif bank_name == "fault":
+                        entities.append(
+                            FaultWarningSensor(sensor, hass, entry, bank_name, dongle_id)
+                        )
+                    elif bank_name == "calculated":
+                        entities.append(
+                            CalculatedSensor(sensor, hass, entry, bank_name, dongle_id)
+                        )
+                    elif bank_name == "temperature":
+                        entities.append(
+                            TemperatureSensor(sensor, hass, entry, bank_name, dongle_id)
+                        )
+                    else:
+                        entities.append(
+                            InverterSensor(sensor, hass, entry, bank_name, dongle_id)
+                        )
+                except Exception as e:
+                    LOGGER.error(f"Error setting up sensor {sensor} for dongle {dongle_id}: {e}")
 
     # Create combined parallel sensors if we have multiple dongles
     if len(dongle_ids) > 1 and "combined" in sensors_config:
@@ -1149,8 +1164,19 @@ class SyncStatusSensor(MonitorMySolarEntity, SensorEntity):
         
         super().__init__(self.coordinator)
         
-        # Start periodic sync status check
-        self.hass.async_create_task(self._start_monitoring())
+        # Start periodic sync status check (but not during startup)
+        if self.coordinator._hass_startup_complete:
+            self.hass.async_create_task(self._start_monitoring())
+        else:
+            # Schedule to start after startup is complete
+            from homeassistant.helpers.event import async_call_later
+            async def start_after_startup(now=None):
+                if self.coordinator._hass_startup_complete:
+                    self.hass.async_create_task(self._start_monitoring())
+                else:
+                    # If still not ready, schedule again
+                    async_call_later(self.hass, 5, start_after_startup)
+            async_call_later(self.hass, 35, start_after_startup)  # Start after our 30s startup delay
     
     async def _start_monitoring(self):
         """Start monitoring sync status."""
@@ -1160,10 +1186,19 @@ class SyncStatusSensor(MonitorMySolarEntity, SensorEntity):
         # Initial check
         await self._check_sync_status()
         
-        # Set up periodic check every 30 seconds
-        while True:
-            await asyncio.sleep(30)
+        # Set up periodic check every 30 seconds using async_call_later instead of blocking loop
+        self._schedule_next_check()
+    
+    def _schedule_next_check(self):
+        """Schedule the next sync status check."""
+        from homeassistant.helpers.event import async_call_later
+        
+        async def check_and_schedule():
             await self._check_sync_status()
+            self._schedule_next_check()  # Schedule the next check
+        
+        # Schedule next check in 30 seconds
+        async_call_later(self.hass, 30, check_and_schedule)
     
     async def _check_sync_status(self):
         """Check the sync status of all monitored settings."""

--- a/custom_components/monitormysolar/switch.py
+++ b/custom_components/monitormysolar/switch.py
@@ -30,6 +30,11 @@ async def async_setup_entry(hass, entry: MonitorMySolarEntry, async_add_entities
     for dongle_id in dongle_ids:
         firmware_code = coordinator.get_firmware_code(dongle_id)
         
+        # Only create entities if we have a firmware code
+        if not firmware_code:
+            _LOGGER.debug(f"Skipping entity creation for {dongle_id} - no firmware code available yet")
+            continue
+        
         # Process switches for this dongle
         for bank_name, switches in switch_config.items():
             # Skip combined switches for individual dongles
@@ -38,13 +43,23 @@ async def async_setup_entry(hass, entry: MonitorMySolarEntry, async_add_entities
                 
             for switch in switches:
                 allowed_firmware_codes = switch.get("allowed_firmware_codes", [])
-                if not allowed_firmware_codes or firmware_code in allowed_firmware_codes:
-                    try:
-                        entities.append(
-                            InverterSwitch(switch, hass, entry, bank_name, dongle_id)
-                        )
-                    except Exception as e:
-                        _LOGGER.error(f"Error setting up switch {switch} for dongle {dongle_id}: {e}")
+                # For GridBoss dongles (IAAB), only create entities that explicitly allow this firmware code
+                if coordinator.is_gridboss_dongle(dongle_id):
+                    if not allowed_firmware_codes or firmware_code not in allowed_firmware_codes:
+                        continue
+                else:
+                    # For regular dongles, use the original logic
+                    if not allowed_firmware_codes or firmware_code in allowed_firmware_codes:
+                        pass  # Continue to entity creation
+                    else:
+                        continue  # Skip this entity
+                
+                try:
+                    entities.append(
+                        InverterSwitch(switch, hass, entry, bank_name, dongle_id)
+                    )
+                except Exception as e:
+                    _LOGGER.error(f"Error setting up switch {switch} for dongle {dongle_id}: {e}")
                         
     # Create combined switches if we have multiple dongles
     if len(dongle_ids) > 1 and "combined" in switch_config:
@@ -102,8 +117,20 @@ class InverterSwitch(MonitorMySolarEntity, SwitchEntity):
     def device_info(self):
         return self.get_device_info(self._dongle_id, self._manufacturer)
 
+    @property
+    def available(self) -> bool:
+        """Check if the switch is available based on coordinator state and conditional logic."""
+        if not self.coordinator.last_update_success:
+            return False
+        
+        # Check if entity should be available based on Port Mode, SOC/Volt settings, and SmartLoad enable state
+        return self.coordinator.is_entity_available_for_smartload(self._dongle_id, self._entity_type)
+
     async def async_turn_on(self, **kwargs):
         """Turn the switch on."""
+        # Allow the action to proceed - availability logic only affects UI display
+        # The MQTT handler will send the command regardless of availability
+        
         mqtt_handler = self.coordinator.mqtt_handler
         if mqtt_handler is not None:
             self._previous_state = self._state
@@ -120,6 +147,9 @@ class InverterSwitch(MonitorMySolarEntity, SwitchEntity):
 
     async def async_turn_off(self, **kwargs):
         """Turn the switch off."""
+        # Allow the action to proceed - availability logic only affects UI display
+        # The MQTT handler will send the command regardless of availability
+        
         mqtt_handler = self.coordinator.mqtt_handler
         if mqtt_handler is not None:
             self._previous_state = self._state  # Save the current state before changing
@@ -139,6 +169,7 @@ class InverterSwitch(MonitorMySolarEntity, SwitchEntity):
         if self._previous_state is not None:
             self._state = self._previous_state
             self.throttled_async_write_ha_state()
+    
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/monitormysolar/time.py
+++ b/custom_components/monitormysolar/time.py
@@ -25,13 +25,28 @@ async def async_setup_entry(hass, entry: MonitorMySolarEntry, async_add_entities
     for dongle_id in dongle_ids:
         firmware_code = coordinator.get_firmware_code(dongle_id)
         
+        # Only create entities if we have a firmware code
+        if not firmware_code:
+            LOGGER.debug(f"Skipping entity creation for {dongle_id} - no firmware code available yet")
+            continue
+        
         # Setup Time entities
         time_config = brand_entities.get("time", {})
         for bank_name, time_entities in time_config.items():
             for time_entity in time_entities:
                 allowed_firmware_codes = time_entity.get("allowed_firmware_codes", [])
-                if not allowed_firmware_codes or firmware_code in allowed_firmware_codes:
-                    entities.append(InverterTime(time_entity, hass, entry, dongle_id))
+                # For GridBoss dongles (IAAB), only create entities that explicitly allow this firmware code
+                if coordinator.is_gridboss_dongle(dongle_id):
+                    if not allowed_firmware_codes or firmware_code not in allowed_firmware_codes:
+                        continue
+                else:
+                    # For regular dongles, use the original logic
+                    if not allowed_firmware_codes or firmware_code in allowed_firmware_codes:
+                        pass  # Continue to entity creation
+                    else:
+                        continue  # Skip this entity
+                
+                entities.append(InverterTime(time_entity, hass, entry, dongle_id))
 
     async_add_entities(entities, True)
 
@@ -56,6 +71,16 @@ class InverterTime(MonitorMySolarEntity, TimeEntity):
         super().__init__(self.coordinator)
 
     @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        if not self.coordinator.last_update_success:
+            return False
+        
+        # Check if entity should be available based on SmartLoad SOC/Volt settings
+        return self.coordinator.is_entity_available_for_smartload(self._dongle_id, self._entity_type)
+    
+
+    @property
     def name(self):
         return self._name
 
@@ -74,6 +99,9 @@ class InverterTime(MonitorMySolarEntity, TimeEntity):
     async def async_set_value(self, value):
         """Handle user input and send to MQTT."""
         now = datetime.now()
+
+        # Allow the action to proceed - availability logic only affects UI display
+        # The MQTT handler will send the command regardless of availability
 
         # Check if the state has changed
         if self._state == value or self._state is None:

--- a/custom_components/monitormysolar/translations/strings.json
+++ b/custom_components/monitormysolar/translations/strings.json
@@ -10,7 +10,10 @@
                     "mqtt_username": "MQTT Username",
                     "mqtt_password": "MQTT Password",
                     "dongle_id": "Dongle ID",
+                    "dongle_ip": "Dongle IP Address (optional)",
                     "parallel_inverters": "Setup Multiple Inverters in Parallel",
+                    "has_gridboss": "GridBoss Connected",
+                    "update_interval": "Database Update Interval",
                     "dongle_id_2": "Additional Dongle ID #2 (optional)",
                     "dongle_id_3": "Additional Dongle ID #3 (optional)",
                     "dongle_id_4": "Additional Dongle ID #4 (optional)"
@@ -21,11 +24,21 @@
             "parallel": {
                 "data": {
                     "dongle_id_2": "Dongle ID #2",
+                    "dongle_ip_2": "Dongle IP #2 (optional)",
                     "dongle_id_3": "Dongle ID #3",
-                    "dongle_id_4": "Dongle ID #4"
+                    "dongle_ip_3": "Dongle IP #3 (optional)",
+                    "dongle_id_4": "Dongle ID #4",
+                    "dongle_ip_4": "Dongle IP #4 (optional)"
                 },
                 "description": "Enter the additional dongle IDs for your parallel inverters.",
                 "title": "Multiple Inverter Configuration"
+            },
+            "gridboss": {
+                "data": {
+                    "gridboss_dongle": "GridBoss Dongle"
+                },
+                "description": "Select which dongle is connected to your GridBoss unit.",
+                "title": "GridBoss Configuration"
             }
         },
         "error": {
@@ -43,7 +56,10 @@
                     "mqtt_username": "Nombre de usuario MQTT",
                     "mqtt_password": "Contraseña MQTT",
                     "dongle_id": "ID del Dongle",
+                    "dongle_ip": "Dirección IP del Dongle (opcional)",
                     "parallel_inverters": "Configurar Múltiples Inversores en Paralelo",
+                    "has_gridboss": "GridBoss Conectado",
+                    "update_interval": "Intervalo de Actualización de Base de Datos",
                     "dongle_id_2": "ID de Dongle Adicional #2 (opcional)",
                     "dongle_id_3": "ID de Dongle Adicional #3 (opcional)",
                     "dongle_id_4": "ID de Dongle Adicional #4 (opcional)"
@@ -54,11 +70,21 @@
             "parallel": {
                 "data": {
                     "dongle_id_2": "ID de Dongle #2",
+                    "dongle_ip_2": "IP de Dongle #2 (opcional)",
                     "dongle_id_3": "ID de Dongle #3",
-                    "dongle_id_4": "ID de Dongle #4"
+                    "dongle_ip_3": "IP de Dongle #3 (opcional)",
+                    "dongle_id_4": "ID de Dongle #4",
+                    "dongle_ip_4": "IP de Dongle #4 (opcional)"
                 },
                 "description": "Ingrese los IDs de dongle adicionales para sus inversores en paralelo.",
                 "title": "Configuración de Múltiples Inversores"
+            },
+            "gridboss": {
+                "data": {
+                    "gridboss_dongle": "Dongle GridBoss"
+                },
+                "description": "Seleccione qué dongle está conectado a su unidad GridBoss.",
+                "title": "Configuración de GridBoss"
             }
         },
         "error": {

--- a/tatus
+++ b/tatus
@@ -1,0 +1,3 @@
+[33m19e94a3[m[33m ([m[1;36mHEAD[m[33m -> [m[1;32mmonitormysolarDEV[m[33m)[m updates to Gridboss logic
+[33mcf05864[m[33m ([m[1;31morigin/monitormysolarDEV[m[33m)[m Bug fix on energy dash for some users, added more combined entities for paralel inverters
+[33medbfd83[m Attempt 2

--- a/tatus
+++ b/tatus
@@ -1,3 +1,0 @@
-[33m19e94a3[m[33m ([m[1;36mHEAD[m[33m -> [m[1;32mmonitormysolarDEV[m[33m)[m updates to Gridboss logic
-[33mcf05864[m[33m ([m[1;31morigin/monitormysolarDEV[m[33m)[m Bug fix on energy dash for some users, added more combined entities for paralel inverters
-[33medbfd83[m Attempt 2


### PR DESCRIPTION
## Version 3.1.0 - GridBoss Enhancements & Performance Improvements

### 🔄 **Important: GridBoss Upgrade Instructions**
If you are using GridBoss functionality, please follow these steps to upgrade:
1. **Delete the integration** from Home Assistant
2. **Reboot** Home Assistant
3. **Update through HACS** to get the latest version
4. **Re-setup** the integration with your GridBoss configuration

This ensures a clean upgrade and prevents any configuration conflicts with the new GridBoss features.
- **Multi-Inverter**: Enhanced support for parallel inverter configurations with GridBoss

### 🚀 Major Performance Improvements
- **Fixed Home Assistant Slow Startup**: Implemented startup delay to prevent MQTT message processing during HA initialization
- **Eliminated Excessive Coordinator Updates**: Reduced coordinator update frequency from every 1.5 seconds to only when needed
- **Optimized MQTT Processing**: Deferred non-critical MQTT message processing until after HA startup completion
- **Improved Main Thread Performance**: Prevented blocking operations during Home Assistant startup
- **Resolved Bootstrap Timeout**: Fixed blocking `while True:` loop in SyncStatusSensor that was causing 5+ minute startup times
- **Non-Blocking Async Scheduling**: Replaced blocking loops with proper async scheduling using `async_call_later()`

### 🔧 GridBoss Configuration & Setup Fixes
- **Enhanced Config Flow**: Added dedicated GridBoss configuration step with proper dongle selection
- **Improved Error Handling**: Added comprehensive error handling for dongle connectivity and firmware code reception
- **Fixed Entity Creation Logic**: Implemented strict GridBoss entity filtering to prevent creation of unnecessary standard entities
- **Corrected Device Naming**: Fixed GridBoss device naming to display "GridBoss" instead of generic names

### 📡 GridBoss MQTT & Payload Processing
- **Fixed Nested Payload Parsing**: Implemented proper handling of GridBoss nested JSON payload structure
- **Corrected Entity Name Mapping**: Fixed mapping between payload keys and entity unique_ids
- **Enhanced Topic Routing**: Improved MQTT topic routing for GridBoss-specific settings
- **Simplified Payload Processing**: Streamlined nested data processing with recursive flattening

### 🛠️ Technical Improvements
- **Removed Complex Throttling**: Simplified coordinator update mechanism for better performance
- **Enhanced Fault/Warning Deduplication**: Prevented duplicate processing of identical fault/warning data
- **Improved Entity Type Determination**: Optimized entity type detection for better performance
- **Better Error Recovery**: Enhanced error handling and recovery mechanisms

### 🎯 User Experience Enhancements
- **Faster Home Assistant Startup**: Reduced startup time by deferring MQTT processing
- **Cleaner Debug Logs**: Eliminated excessive "Manually updated MonitorySolar Coordinator data" messages
- **More Responsive Interface**: Home Assistant becomes responsive much faster after restart
- **Better Configuration Flow**: Improved GridBoss setup process with clear error messages

### 🔄 Backward Compatibility
- **Maintained All Existing Features**: All previous functionality preserved
- **No Breaking Changes**: Existing configurations continue to work without modification
- **Preserved Entity History**: All entity data and settings remain intact
- **Seamless Upgrade Path**: No manual intervention required for existing users

### 📋 Technical Details
- **Startup Delay**: 30-second delay before MQTT message processing begins
- **Firmware Code Processing**: Still processed immediately for proper entity creation
- **GridBoss Entity Filtering**: Only creates entities explicitly allowed for "IAAB" firmware
- **Payload Structure**: Supports both old and new nested payload formats

### 🐛 Bug Fixes
- Fixed `IndentationError` in sensor.py that prevented integration loading
- Resolved `NameError: name 'data_to_process' is not defined` in coordinator
- Fixed GridBoss entity count issues (was creating ~400 entities, now creates only relevant ones)
- Corrected GridBoss device naming in Home Assistant interface
- Fixed nested payload parsing for GridBoss settings updates
- **Fixed Home Assistant startup timeout**: Replaced blocking `while True:` loop in SyncStatusSensor with non-blocking async scheduling
- **Resolved 5+ minute startup times**: Prevented bootstrap timeout warnings and excessive coordinator updates during startup
- **Fixed GridBoss MQTT routing issue**: GridBoss settings were incorrectly being sent to bank-specific topics instead of the standard `/update` topic, causing settings to be rejected
- **Enhanced GridBoss conditional entity system**: Implemented hierarchical availability logic based on Port Mode → SOC/Volt mode → Enable state
- **Added Port Mode selects**: New SmartLoad1-4 Port Mode selects with proper numeric value mapping (0=Does Not Operate, 1=Smart Load, 2=AC Coupled)
- **Fixed switch availability logic**: Added proper availability checking to switch entities based on Port Mode, SOC/Volt mode, and SmartLoad enable state
- **Firmware code persistence**: Firmware codes are now saved to config entry data and only requested when not already available, improving startup performance
- **Fixed availability timing issue**: Added 0.5s delay to availability updates to prevent blocking legitimate user actions when Port Mode changes
- **Removed availability blocking from user actions**: Availability logic now only affects UI display (grayed out entities) but no longer blocks user actions, preventing the "revert" issue
- **Fixed select entity revert issue**: Select entities now properly store previous state before changing and revert correctly on MQTT failure, preventing the auto-revert issue with Port Mode selects
- **Fixed coordinator override issue**: Added user-initiated change flag to prevent coordinator from overriding user selections during MQTT processing, solving the select revert problem
- **Fixed availability delay issue**: Port Mode changes now trigger immediate availability updates, and enable switches are always available when Port Mode is set to "Smart Load" or "AC Coupled" (both SmartLoad and AC Coupled enable switches)
- **Added SOC/Volt mode select entities**: New SmartLoad1-4 Mode selects with "Time" and "SOC/Volt" options, available when Port Mode is set to "Smart Load" or "AC Coupled"

### 📝 Notes
- **Dongle Firmware**: Requires dongle firmware 3.1.0+ for optimal GridBoss functionality
- **Performance**: Significant improvement in Home Assistant startup time
- **GridBoss**: Full support for GridBoss units with firmware code "IAAB"

---