### PR TITLE
tests: use asyncio.run() so the suite runs on Python 3.12+

### DIFF
--- a/tests/test_dongleless_migration.py
+++ b/tests/test_dongleless_migration.py
@@ -76,7 +76,7 @@ def _patch(monkeypatch, reg):
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 def test_single_dongle_removes_orphan(monkeypatch):

--- a/tests/test_ota_snapshot_suppression.py
+++ b/tests/test_ota_snapshot_suppression.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 def test_request_snapshot_suppressed_during_ota(coordinator, monkeypatch):

--- a/tests/test_reclaim_suffixed_ids.py
+++ b/tests/test_reclaim_suffixed_ids.py
@@ -67,7 +67,7 @@ def _patch(monkeypatch, reg):
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 def test_shape_b_base_free_renames_down(monkeypatch):

--- a/tests/test_recovery_snapshot.py
+++ b/tests/test_recovery_snapshot.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 def _prep(coordinator, monkeypatch):

--- a/tests/test_restore_entities.py
+++ b/tests/test_restore_entities.py
@@ -90,7 +90,7 @@ def test_restore_reenables_disabled(monkeypatch):
     migration = _install_er(monkeypatch, reg, entries)
 
     import asyncio
-    n = asyncio.get_event_loop().run_until_complete(
+    n = asyncio.run(
         migration.async_restore_entities(MagicMock(), _Entry(), ["disabled:sensor.b"]))
     assert n == 1
     assert reg.async_get("sensor.b").disabled_by is None
@@ -102,7 +102,7 @@ def test_restore_purges_deleted(monkeypatch):
     migration = _install_er(monkeypatch, reg, [])
 
     import asyncio
-    n = asyncio.get_event_loop().run_until_complete(
+    n = asyncio.run(
         migration.async_restore_entities(MagicMock(), _Entry(), ["deleted:sensor.gone"]))
     assert n == 1
     assert "sensor.gone" not in reg.deleted_entities  # record cleared
@@ -113,7 +113,7 @@ def test_restore_ignores_unknown_keys(monkeypatch):
     reg = _FakeRegistry([], {})
     migration = _install_er(monkeypatch, reg, [])
     import asyncio
-    n = asyncio.get_event_loop().run_until_complete(
+    n = asyncio.run(
         migration.async_restore_entities(MagicMock(), _Entry(),
                                          ["deleted:sensor.nope", "bogus", "disabled:"]))
     assert n == 0

--- a/tests/test_self_write_dedup.py
+++ b/tests/test_self_write_dedup.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock
 
 def _run(coro):
     import asyncio
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 def _prep(coordinator, monkeypatch, entity_type="number"):

--- a/tests/test_snapshot_dispatch.py
+++ b/tests/test_snapshot_dispatch.py
@@ -18,7 +18,7 @@ import pytest
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_startup_gate_failsafe.py
+++ b/tests/test_startup_gate_failsafe.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 def _make_msg(topic, payload):

--- a/tests/test_unified_topics.py
+++ b/tests/test_unified_topics.py
@@ -25,7 +25,7 @@ import pytest
 
 def _run(coro):
     """Tiny event-loop runner so each test can call async process_message."""
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
The test suite can't be collected on a current Python. `asyncio.get_event_loop()` no longer creates a loop implicitly — deprecated in 3.12, removed in 3.14 — so every test using the `_run(...)` helper fails with:

```
RuntimeError: There is no current event loop in thread 'MainThread'.
```

`asyncio.run()` is the documented replacement and is equivalent here: each helper call wraps a single independent coroutine, so there's no shared loop state to preserve across calls.

Mechanical change across 9 test files, no source changes.

**Before** (Python 3.14): collection interrupted, suite unrunnable.
**After:** 175 passed.

Split out from a separate bug-fix branch so it can be reviewed on its own — the fix work is unrelated and just needed a runnable suite.
