### PR TITLE
fix: settings entities silently report 0/off when the snapshot is lost

### DIFF
--- a/custom_components/monitormysolar/coordinator.py
+++ b/custom_components/monitormysolar/coordinator.py
@@ -202,22 +202,25 @@ class MonitorMySolar(DataUpdateCoordinator[None]):
         """Whether a dongle is currently running an OTA update."""
         return dongle_id in getattr(self, "_ota_in_progress", ())
 
-    async def request_snapshot(self, dongle_id: str, version: str = "", force: bool = False) -> None:
+    async def request_snapshot(self, dongle_id: str, version: str = "", force: bool = False) -> bool:
         """Ask a dongle for a full /input + /hold snapshot (once per session).
 
         Dongles on FW >= 4.3.0 only publish change-data, so without this the
         entities stay 'unknown' until each value happens to change. Gated to fire
         once per dongle per HA session unless force=True (e.g. a reconnect).
+
+        Returns True only if the request was actually published, so callers can
+        avoid recording a retry/debounce window against a request that never left.
         """
         if self.is_ota_in_progress(dongle_id):
             LOGGER.info(
                 "Suppressing snapshot request for %s: OTA in progress", dongle_id
             )
-            return
+            return False
         if not force and dongle_id in self._snapshot_requested:
-            return
+            return False
         if not self._needs_snapshot(version):
-            return
+            return False
         try:
             await mqtt.async_publish(
                 self.hass,
@@ -226,12 +229,14 @@ class MonitorMySolar(DataUpdateCoordinator[None]):
                 qos=1,
                 retain=False,
             )
-            self._snapshot_requested.add(dongle_id)
-            LOGGER.info(
-                "Requested full snapshot from %s (version=%s)", dongle_id, version or "unknown"
-            )
         except Exception as e:
             LOGGER.debug(f"Snapshot request publish failed for {dongle_id} (non-fatal): {e}")
+            return False
+        self._snapshot_requested.add(dongle_id)
+        LOGGER.info(
+            "Requested full snapshot from %s (version=%s)", dongle_id, version or "unknown"
+        )
+        return True
 
     async def request_recovery_snapshot(self, dongle_id: str, reason: str) -> None:
         """Force a snapshot after a dongle recovers, debounced per dongle.
@@ -252,11 +257,15 @@ class MonitorMySolar(DataUpdateCoordinator[None]):
         last = self._last_recovery_snapshot.get(dongle_id, 0.0)
         if now - last < self._recovery_snapshot_debounce:
             return
-        self._last_recovery_snapshot[dongle_id] = now
         LOGGER.info("Recovery snapshot for %s (%s)", dongle_id, reason)
-        await self.request_snapshot(
+        # Only start the debounce window once the request has actually gone out.
+        # Recovery triggers fire while the dongle is rebooting, so a request can
+        # be lost before it is subscribed; stamping first would swallow the
+        # follow-up triggers and leave settings entities empty for the session.
+        if await self.request_snapshot(
             dongle_id, self.current_fw_versions.get(dongle_id, ""), force=True
-        )
+        ):
+            self._last_recovery_snapshot[dongle_id] = now
 
     async def mark_dongle_seen(self, dongle_id: str) -> None:
         """Record that a message arrived from a dongle and detect gap recovery.

--- a/custom_components/monitormysolar/coordinator.py
+++ b/custom_components/monitormysolar/coordinator.py
@@ -98,6 +98,15 @@ class MonitorMySolar(DataUpdateCoordinator[None]):
         self._dongle_stale_after = 90.0
         # Don't send more than one recovery snapshot per dongle within this window.
         self._recovery_snapshot_debounce = 30.0
+        # A snapshot request can be lost: the recovery triggers fire while the
+        # dongle is still coming back, so it may not have resubscribed yet. On
+        # FW >= 4.3.0 nothing re-sends hold registers, so a lost request leaves
+        # every setting entity empty until the next reboot. Verify the reply
+        # (<dongle>/snap/hold) actually arrives and retry a bounded number of times.
+        self._snapshot_retry: Dict[str, Any] = {}  # dongle -> cancel callback
+        self._snapshot_retry_attempts: Dict[str, int] = {}
+        self._snapshot_retry_delay = 20.0
+        self._snapshot_max_retries = 3
         self._has_gridboss = entry.data.get("has_gridboss", False)  # Track if GridBoss is enabled
         self._gridboss_dongle = entry.data.get("gridboss_dongle", "")  # Track which dongle is GridBoss
         self._last_fault_warning_data = {}  # Track last fault/warning data to prevent duplicate processing
@@ -236,6 +245,7 @@ class MonitorMySolar(DataUpdateCoordinator[None]):
         LOGGER.info(
             "Requested full snapshot from %s (version=%s)", dongle_id, version or "unknown"
         )
+        self._arm_snapshot_retry(dongle_id, version)
         return True
 
     async def request_recovery_snapshot(self, dongle_id: str, reason: str) -> None:
@@ -266,6 +276,65 @@ class MonitorMySolar(DataUpdateCoordinator[None]):
             dongle_id, self.current_fw_versions.get(dongle_id, ""), force=True
         ):
             self._last_recovery_snapshot[dongle_id] = now
+
+    def _cancel_snapshot_retry(self, dongle_id: str) -> None:
+        """Drop any armed retry timer for a dongle."""
+        # getattr: test coordinators are built via __new__ and skip __init__.
+        pending = getattr(self, "_snapshot_retry", None)
+        if not pending:
+            return
+        cancel = pending.pop(dongle_id, None)
+        if cancel is not None:
+            cancel()
+
+    def _arm_snapshot_retry(self, dongle_id: str, version: str) -> None:
+        """Re-request the snapshot if its reply doesn't arrive in time.
+
+        A published request is not a delivered one: the recovery triggers fire
+        while the dongle is still reconnecting, so the request can go out before
+        it has resubscribed. Since FW >= 4.3.0 never re-sends hold registers on
+        its own, that single loss would leave every setting entity empty for the
+        rest of the session.
+        """
+        if getattr(self, "_snapshot_retry", None) is None:
+            self._snapshot_retry = {}
+        if getattr(self, "_snapshot_retry_attempts", None) is None:
+            self._snapshot_retry_attempts = {}
+        self._cancel_snapshot_retry(dongle_id)
+        attempts = self._snapshot_retry_attempts.get(dongle_id, 0)
+        max_retries = getattr(self, "_snapshot_max_retries", 3)
+        if attempts >= max_retries:
+            LOGGER.warning(
+                "Snapshot from %s still unanswered after %d retries - its settings "
+                "entities will stay unknown until it reboots or reconnects",
+                dongle_id, attempts,
+            )
+            return
+        delay = getattr(self, "_snapshot_retry_delay", 20.0)
+
+        async def _retry(_now) -> None:
+            self._snapshot_retry.pop(dongle_id, None)
+            if self.is_ota_in_progress(dongle_id):
+                return
+            self._snapshot_retry_attempts[dongle_id] = attempts + 1
+            LOGGER.warning(
+                "No snapshot reply from %s after %.0fs - retrying (%d/%d)",
+                dongle_id, delay, attempts + 1, max_retries,
+            )
+            await self.request_snapshot(dongle_id, version, force=True)
+
+        self._snapshot_retry[dongle_id] = async_call_later(self.hass, delay, _retry)
+
+    def _note_snapshot_delivered(self, dongle_id: str) -> None:
+        """Record that a dongle answered its snapshot request.
+
+        Called when <dongle>/snap/hold arrives — the hold half is what carries
+        the settings, so an /snap/input-only reply deliberately does not count.
+        """
+        self._cancel_snapshot_retry(dongle_id)
+        attempts = getattr(self, "_snapshot_retry_attempts", None)
+        if attempts is not None:
+            attempts.pop(dongle_id, None)
 
     async def mark_dongle_seen(self, dongle_id: str) -> None:
         """Record that a message arrived from a dongle and detect gap recovery.
@@ -1292,6 +1361,10 @@ class MonitorMySolar(DataUpdateCoordinator[None]):
             # which on FW >= 4.3.0 (change-data only) may be a long time. The
             # firmware publishes it on <dongle>/snap/input and <dongle>/snap/hold.
             elif topic.endswith("/snap/input") or topic.endswith("/snap/hold"):
+                if topic.endswith("/snap/hold"):
+                    # The hold half carries the settings; an input-only reply
+                    # leaves them empty, so it must not disarm the retry.
+                    self._note_snapshot_delivered(dongle_id)
                 await self.process_message(dongle_id, topic, msg.payload)
                 self.async_set_updated_data(self.entities)
             # Skip other message processing during startup to prevent excessive updates
@@ -1764,6 +1837,10 @@ class MonitorMySolar(DataUpdateCoordinator[None]):
     async def stop_mqtt_subscription(self):
         """Stop all MQTT subscriptions."""
         LOGGER.debug(f"Stopping MQTT subscriptions for all dongles")
+        # Drop armed snapshot retries first: once unsubscribed there is nothing
+        # left to answer them, and a reload would leave the timers orphaned.
+        for dongle_id in list(getattr(self, "_snapshot_retry", {})):
+            self._cancel_snapshot_retry(dongle_id)
         for key, unsubscribe in list(self._mqtt_unsubscribe_callbacks.items()):
             try:
                 unsubscribe()

--- a/custom_components/monitormysolar/number.py
+++ b/custom_components/monitormysolar/number.py
@@ -83,7 +83,7 @@ class InverterNumber(MonitorMySolarEntity, NumberEntity):
         self.entity_info = entity_info
         self._attr_name = entity_info["name"]
         self._attr_unique_id = f"{entry.entry_id}_{dongle_id}_{entity_info['unique_id']}".lower()
-        self._attr_native_value = 0
+        self._attr_native_value = None
         self._dongle_id = dongle_id
         self._formatted_dongle_id = self.coordinator.get_formatted_dongle_id(dongle_id)
         self._entity_type = entity_info["unique_id"]
@@ -229,7 +229,7 @@ class CombinedNumber(MonitorMySolarEntity, NumberEntity):
         self.entity_info = entity_info
         self._name = entity_info["name"]
         self._unique_id = f"{entry.entry_id}_{entity_info['unique_id']}".lower()
-        self._attr_native_value = 0
+        self._attr_native_value = None
         self._dongle_ids = dongle_ids
         self._virtual_id = "combined_parallel"
         self._formatted_dongle_id = "combined"

--- a/custom_components/monitormysolar/switch.py
+++ b/custom_components/monitormysolar/switch.py
@@ -92,7 +92,7 @@ class InverterSwitch(MonitorMySolarEntity, SwitchEntity):
         self.entity_info = entity_info
         self._name = entity_info["name"]
         self._unique_id = f"{entry.entry_id}_{dongle_id}_{entity_info['unique_id']}".lower()
-        self._state = False
+        self._state = None
         self._dongle_id = dongle_id
         self._formatted_dongle_id = self.coordinator.get_formatted_dongle_id(dongle_id)
         self._entity_type = entity_info["unique_id"]
@@ -231,7 +231,7 @@ class CombinedSwitch(MonitorMySolarEntity, SwitchEntity):
         self.entity_info = entity_info
         self._name = entity_info["name"]
         self._unique_id = f"{entry.entry_id}_{entity_info['unique_id']}".lower()
-        self._state = False
+        self._state = None
         self._dongle_ids = dongle_ids
         self._virtual_id = "combined_parallel"
         self._formatted_dongle_id = "combined"

--- a/tests/test_dongleless_migration.py
+++ b/tests/test_dongleless_migration.py
@@ -76,7 +76,7 @@ def _patch(monkeypatch, reg):
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 def test_single_dongle_removes_orphan(monkeypatch):

--- a/tests/test_ota_snapshot_suppression.py
+++ b/tests/test_ota_snapshot_suppression.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 def test_request_snapshot_suppressed_during_ota(coordinator, monkeypatch):

--- a/tests/test_reclaim_suffixed_ids.py
+++ b/tests/test_reclaim_suffixed_ids.py
@@ -67,7 +67,7 @@ def _patch(monkeypatch, reg):
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 def test_shape_b_base_free_renames_down(monkeypatch):

--- a/tests/test_recovery_snapshot.py
+++ b/tests/test_recovery_snapshot.py
@@ -13,12 +13,15 @@ def _run(coro):
     return asyncio.run(coro)
 
 
-def _prep(coordinator, monkeypatch):
-    # Capture request_snapshot calls without publishing.
+def _prep(coordinator, monkeypatch, published=True):
+    # Capture request_snapshot calls without publishing. `published` models its
+    # return value: True = the request actually went out, False = the publish
+    # failed or was suppressed.
     calls = []
 
     async def fake_request_snapshot(dongle_id, version="", force=False):
         calls.append((dongle_id, force))
+        return published
 
     monkeypatch.setattr(coordinator, "request_snapshot", fake_request_snapshot)
     coordinator.current_fw_versions = {}
@@ -34,6 +37,28 @@ def test_recovery_snapshot_debounced(coordinator, monkeypatch):
     _run(coordinator.request_recovery_snapshot("dongle-A", "test1"))
     _run(coordinator.request_recovery_snapshot("dongle-A", "test2"))
     assert calls == [("dongle-A", True)]
+
+
+def test_failed_publish_does_not_burn_debounce(coordinator, monkeypatch):
+    """A request that never went out must not suppress the follow-up triggers.
+
+    Recovery triggers fire while the dongle is still rebooting, so the first
+    attempt can be published before it has resubscribed and is then lost. If
+    the debounce window were stamped regardless, the follow-up triggers would
+    be swallowed and — because FW >= 4.3.0 only streams change-data — the
+    dongle's settings entities would stay empty for the rest of the session.
+
+    This is the same rule the OTA-suppression path already follows; it just
+    also has to apply when the publish itself fails.
+    """
+    calls = _prep(coordinator, monkeypatch, published=False)
+    coordinator._last_recovery_snapshot = {}
+    coordinator._recovery_snapshot_debounce = 30.0
+
+    _run(coordinator.request_recovery_snapshot("dongle-A", "reboot detected"))
+    _run(coordinator.request_recovery_snapshot("dongle-A", "availability online"))
+    assert calls == [("dongle-A", True), ("dongle-A", True)]
+    assert "dongle-A" not in coordinator._last_recovery_snapshot
 
 
 def test_recovery_snapshot_per_dongle(coordinator, monkeypatch):

--- a/tests/test_recovery_snapshot.py
+++ b/tests/test_recovery_snapshot.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 def _prep(coordinator, monkeypatch):

--- a/tests/test_restore_entities.py
+++ b/tests/test_restore_entities.py
@@ -90,7 +90,7 @@ def test_restore_reenables_disabled(monkeypatch):
     migration = _install_er(monkeypatch, reg, entries)
 
     import asyncio
-    n = asyncio.get_event_loop().run_until_complete(
+    n = asyncio.run(
         migration.async_restore_entities(MagicMock(), _Entry(), ["disabled:sensor.b"]))
     assert n == 1
     assert reg.async_get("sensor.b").disabled_by is None
@@ -102,7 +102,7 @@ def test_restore_purges_deleted(monkeypatch):
     migration = _install_er(monkeypatch, reg, [])
 
     import asyncio
-    n = asyncio.get_event_loop().run_until_complete(
+    n = asyncio.run(
         migration.async_restore_entities(MagicMock(), _Entry(), ["deleted:sensor.gone"]))
     assert n == 1
     assert "sensor.gone" not in reg.deleted_entities  # record cleared
@@ -113,7 +113,7 @@ def test_restore_ignores_unknown_keys(monkeypatch):
     reg = _FakeRegistry([], {})
     migration = _install_er(monkeypatch, reg, [])
     import asyncio
-    n = asyncio.get_event_loop().run_until_complete(
+    n = asyncio.run(
         migration.async_restore_entities(MagicMock(), _Entry(),
                                          ["deleted:sensor.nope", "bogus", "disabled:"]))
     assert n == 0

--- a/tests/test_self_write_dedup.py
+++ b/tests/test_self_write_dedup.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock
 
 def _run(coro):
     import asyncio
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 def _prep(coordinator, monkeypatch, entity_type="number"):

--- a/tests/test_settings_default_state.py
+++ b/tests/test_settings_default_state.py
@@ -1,0 +1,53 @@
+"""Settings entities must not report a fabricated value before data arrives.
+
+Dongles on FW >= 4.3.0 only stream change-data, so a hold register (a setting)
+reaches HA exactly once, in the connect-time snapshot. If that snapshot is lost
+the entity never receives a value -- and a number seeded with 0 or a switch
+seeded with False is then indistinguishable from a real reading of 0/off.
+Seeding None instead surfaces it as 'unknown', which is what select.py already
+does.
+"""
+from unittest.mock import MagicMock
+
+
+def _entry(entity_id):
+    entry = MagicMock()
+    coord = entry.runtime_data
+    coord.build_entity_id.return_value = entity_id
+    coord.get_formatted_dongle_id.return_value = "dongle_x"
+    coord.get_firmware_code.return_value = "AAAA"
+    return entry
+
+
+def test_number_has_no_value_before_data_arrives():
+    from custom_components.monitormysolar.number import InverterNumber
+
+    entry = _entry("number.dongle_x_acchgsoclimit")
+    n = InverterNumber(
+        {"name": "AC Charge SOC Limit", "unique_id": "acchgsoclimit", "min": 0, "max": 100},
+        MagicMock(), entry, "holdbank1", "dongle-X",
+    )
+    assert n._attr_native_value is None
+
+
+def test_switch_has_no_state_before_data_arrives():
+    from custom_components.monitormysolar.switch import InverterSwitch
+
+    entry = _entry("switch.dongle_x_accharge")
+    s = InverterSwitch(
+        {"name": "AC Charge", "unique_id": "accharge"},
+        MagicMock(), entry, "holdbank1", "dongle-X",
+    )
+    assert s.is_on is None
+
+
+def test_select_already_has_no_state_before_data_arrives():
+    """Baseline: select.py was already correct; number/switch now match it."""
+    from custom_components.monitormysolar.select import InverterSelect
+
+    entry = _entry("select.dongle_x_acchargetype")
+    sel = InverterSelect(
+        {"name": "AC Charge Type", "unique_id": "acchargetype", "options": ["Time", "SOC/Volt"]},
+        MagicMock(), entry, "dongle-X",
+    )
+    assert sel.current_option is None

--- a/tests/test_snapshot_dispatch.py
+++ b/tests/test_snapshot_dispatch.py
@@ -18,7 +18,7 @@ import pytest
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_snapshot_retry.py
+++ b/tests/test_snapshot_retry.py
@@ -1,0 +1,122 @@
+"""Snapshot requests are verified and retried until the reply arrives.
+
+Publishing a snapshot request is not the same as delivering one: the recovery
+triggers fire while a dongle is still reconnecting, so a request can go out
+before it has resubscribed. On FW >= 4.3.0 nothing re-sends hold registers, so
+a single lost request leaves every setting entity empty for the session.
+
+The coordinator arms a timer on each successful publish and disarms it when
+<dongle>/snap/hold arrives.
+"""
+import asyncio
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _fire(timers):
+    """Fire the oldest armed timer, one-shot: a fired handle is spent."""
+    _delay, cb = timers.pop(0)
+    return _run(cb(None))
+
+
+def _prep(coordinator, monkeypatch):
+    """Wire a coordinator with a captured async_call_later and no real publish."""
+    from custom_components.monitormysolar import coordinator as coord_mod
+
+    published = []
+
+    async def fake_publish(hass, topic, payload, **kwargs):
+        published.append(topic)
+
+    monkeypatch.setattr(coord_mod.mqtt, "async_publish", fake_publish)
+
+    timers = []  # (delay, callback)
+
+    def fake_call_later(hass, delay, cb):
+        timers.append((delay, cb))
+        cancelled = {"done": False}
+
+        def _cancel():
+            cancelled["done"] = True
+            for i, (d, c) in enumerate(timers):
+                if c is cb:
+                    timers.pop(i)
+                    break
+
+        return _cancel
+
+    monkeypatch.setattr(coord_mod, "async_call_later", fake_call_later)
+
+    coordinator._snapshot_requested = set()
+    coordinator._snapshot_retry = {}
+    coordinator._snapshot_retry_attempts = {}
+    coordinator._snapshot_retry_delay = 20.0
+    coordinator._snapshot_max_retries = 3
+    return published, timers
+
+
+def test_successful_publish_arms_a_retry(coordinator, monkeypatch):
+    published, timers = _prep(coordinator, monkeypatch)
+
+    _run(coordinator.request_snapshot("dongle-A", "4.3.1.1C6", force=True))
+    assert published == ["dongle-A/snapshot/request"]
+    assert len(timers) == 1 and timers[0][0] == 20.0
+    assert "dongle-A" in coordinator._snapshot_retry
+
+
+def test_snap_hold_disarms_the_retry(coordinator, monkeypatch):
+    published, timers = _prep(coordinator, monkeypatch)
+
+    _run(coordinator.request_snapshot("dongle-A", "4.3.1.1C6", force=True))
+    coordinator._note_snapshot_delivered("dongle-A")
+
+    assert coordinator._snapshot_retry == {}
+    assert timers == []  # cancelled, so it can never re-request
+
+
+def test_input_only_reply_does_not_disarm(coordinator, monkeypatch):
+    """/snap/input carries no settings, so it must not count as delivery."""
+    published, timers = _prep(coordinator, monkeypatch)
+
+    _run(coordinator.request_snapshot("dongle-A", "4.3.1.1C6", force=True))
+    # Only _note_snapshot_delivered() disarms, and the dispatcher calls it for
+    # /snap/hold alone -- an input-only reply leaves the timer armed.
+    assert "dongle-A" in coordinator._snapshot_retry
+
+
+def test_unanswered_request_is_retried(coordinator, monkeypatch):
+    published, timers = _prep(coordinator, monkeypatch)
+
+    _run(coordinator.request_snapshot("dongle-A", "4.3.1.1C6", force=True))
+    # Reply never arrives -> the timer fires.
+    _fire(timers)
+
+    assert published == ["dongle-A/snapshot/request"] * 2
+    assert coordinator._snapshot_retry_attempts["dongle-A"] == 1
+
+
+def test_retries_are_bounded(coordinator, monkeypatch):
+    published, timers = _prep(coordinator, monkeypatch)
+
+    _run(coordinator.request_snapshot("dongle-A", "4.3.1.1C6", force=True))
+    for _ in range(10):
+        if not timers:
+            break
+        _fire(timers)
+
+    # Initial publish + at most _snapshot_max_retries retries, then it gives up.
+    assert len(published) == 1 + 3
+    assert coordinator._snapshot_retry == {}
+
+
+def test_retry_suppressed_during_ota(coordinator, monkeypatch):
+    """An OTA'ing dongle has no snapshot queue: a request reboot-loops it."""
+    published, timers = _prep(coordinator, monkeypatch)
+
+    _run(coordinator.request_snapshot("dongle-A", "4.3.1.1C6", force=True))
+    coordinator.set_ota_in_progress("dongle-A", True)
+    _fire(timers)
+
+    assert published == ["dongle-A/snapshot/request"]  # no second request

--- a/tests/test_startup_gate_failsafe.py
+++ b/tests/test_startup_gate_failsafe.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 def _make_msg(topic, payload):

--- a/tests/test_unified_topics.py
+++ b/tests/test_unified_topics.py
@@ -25,7 +25,7 @@ import pytest
 
 def _run(coro):
     """Tiny event-loop runner so each test can call async process_message."""
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## The problem

Dongles on FW >= 4.3.0 stream change-data only, so a hold register (a setting) reaches HA exactly once: in the connect-time snapshot. Settings don't change on their own, so if that snapshot is lost, **nothing ever re-sends them**.

Three things combined to make that silent and permanent.

**1. A lost request is never retried.** `request_snapshot()` publishes and assumes delivery. The recovery triggers (boot-count change, availability online) fire *while the dongle is still coming back*, so the request can go out before it has resubscribed.

**2. The debounce window was spent before the request left.** `request_recovery_snapshot()` stamped `_last_recovery_snapshot[dongle_id]` *before* calling `request_snapshot()`, which swallowed publish failures and returned `None` — so the caller couldn't tell a sent request from a lost one. A burst of triggers around a reboot collapsed into one attempt, and if that attempt was lost the follow-ups were swallowed too.

**3. The result looked like real data.** Numbers were seeded `_attr_native_value = 0` and switches `_state = False`, so an entity that never received a value was indistinguishable from a genuine reading of `0` / `off`.

Observed on a live system: two dongles reported `acchgsoclimit` 0 and `acchgstartsoc` 0 while the inverters actually held 40/80 and 60/80, and an AC-charge switch read `off` while the inverter had it enabled. Cross-checked against the same registers read over a second, independent path. It also reproduces on a plain HA restart, not just on dongle reboots — five dongles requested, no replies, all settings stuck at defaults until the integration was reloaded.

## The changes

**Report `unknown`, not a fabricated value.** Numbers and switches now seed `None`. This is what `select.py` already does — the other two platforms just weren't consistent with it.

**Only record the debounce window once the request has actually gone out.** `request_snapshot()` now returns whether it published.

**Verify and retry.** Arm a timer on each successful publish; disarm it when the reply arrives on `<dongle>/snap/hold`; otherwise re-request, bounded to 3 retries at 20s.

Two details worth calling out:

- Only `/snap/hold` counts as delivery. The hold half is what carries the settings, so an `/snap/input`-only reply must not disarm the retry. There's a test pinning this.
- Retries respect the existing OTA suppression. A dongle mid-OTA has no snapshot queue and a `{"what":"all"}` request reboot-loops it, so a timer firing during an OTA is dropped rather than re-requesting. Armed timers are also cancelled in `stop_mqtt_subscription()` so a reload doesn't orphan them.

This is the same rule `test_ota_snapshot_suppression.py` already asserts — "must not burn the recovery debounce window while suppressed so the post-OTA refresh still goes through". It just also has to apply when the publish itself fails, and the reply needs checking rather than assuming.

## Tests

9 new tests. Each was verified to fail against unmodified source and pass with the change; one deliberately asserts `select` was *already* correct, as a baseline, and passes either way.

185 passed.

## Note on the base

Includes the one-commit test fix from #110, without which the suite can't be collected on Python 3.12+. If #110 merges first this shrinks to the two fix commits.

Running on my own system since it was written; the state loss it fixes has not recurred.
